### PR TITLE
Add auto-pull feature for sessions

### DIFF
--- a/cmd/project_add.go
+++ b/cmd/project_add.go
@@ -13,6 +13,7 @@ var (
 	projectName          string
 	projectDesc          string
 	projectDefaultBranch string
+	projectAutoPull      bool
 )
 
 var projectAddCmd = &cobra.Command{
@@ -23,7 +24,8 @@ var projectAddCmd = &cobra.Command{
 Examples:
   devx project add . --alias myapp
   devx project add ~/code/backend --alias backend --name "Backend API"
-  devx project add /path/to/frontend --alias fe --desc "React frontend" --default-branch develop`,
+  devx project add /path/to/frontend --alias fe --desc "React frontend" --default-branch develop
+  devx project add . --alias myapp --auto-pull  # Auto-pull from origin when creating sessions`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		projectPath := args[0]
@@ -78,10 +80,11 @@ Examples:
 
 		// Create project
 		project := &config.Project{
-			Name:          projectName,
-			Path:          absPath,
-			Description:   projectDesc,
-			DefaultBranch: projectDefaultBranch,
+			Name:             projectName,
+			Path:             absPath,
+			Description:      projectDesc,
+			DefaultBranch:    projectDefaultBranch,
+			AutoPullOnCreate: projectAutoPull,
 		}
 
 		// Add to registry
@@ -111,6 +114,7 @@ func init() {
 	projectAddCmd.Flags().StringVarP(&projectName, "name", "n", "", "Display name for the project")
 	projectAddCmd.Flags().StringVarP(&projectDesc, "desc", "d", "", "Description of the project")
 	projectAddCmd.Flags().StringVar(&projectDefaultBranch, "default-branch", "main", "Default branch for new sessions")
+	projectAddCmd.Flags().BoolVar(&projectAutoPull, "auto-pull", false, "Automatically pull from origin when creating sessions")
 
 	_ = projectAddCmd.MarkFlagRequired("alias")
 }

--- a/cmd/project_set.go
+++ b/cmd/project_set.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jfox85/devx/config"
+	"github.com/spf13/cobra"
+)
+
+var projectSetCmd = &cobra.Command{
+	Use:   "set <alias> <key> <value>",
+	Short: "Set a project configuration value",
+	Long: `Set a configuration value for a specific project.
+
+Available keys:
+  name             - Display name of the project
+  description      - Description of the project
+  default-branch   - Default branch for new sessions (e.g., main, master)
+  auto-pull        - Automatically pull from origin when creating sessions (true/false)
+
+Examples:
+  devx project set myapp auto-pull true
+  devx project set backend default-branch develop
+  devx project set frontend description "React frontend application"`,
+	Args: cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		alias := args[0]
+		key := args[1]
+		value := args[2]
+
+		// Load project registry
+		registry, err := config.LoadProjectRegistry()
+		if err != nil {
+			return fmt.Errorf("failed to load project registry: %w", err)
+		}
+
+		// Get the project
+		project, err := registry.GetProject(alias)
+		if err != nil {
+			return err
+		}
+
+		// Update the specified field
+		switch key {
+		case "name":
+			project.Name = value
+			fmt.Printf("Set project '%s' name to: %s\n", alias, value)
+
+		case "description", "desc":
+			project.Description = value
+			fmt.Printf("Set project '%s' description to: %s\n", alias, value)
+
+		case "default-branch":
+			project.DefaultBranch = value
+			fmt.Printf("Set project '%s' default branch to: %s\n", alias, value)
+
+		case "auto-pull":
+			// Parse boolean value
+			boolValue, err := strconv.ParseBool(strings.ToLower(value))
+			if err != nil {
+				return fmt.Errorf("auto-pull must be true or false")
+			}
+			project.AutoPullOnCreate = boolValue
+			fmt.Printf("Set project '%s' auto-pull to: %v\n", alias, boolValue)
+
+		default:
+			return fmt.Errorf("unknown configuration key: %s\n\nAvailable keys: name, description, default-branch, auto-pull", key)
+		}
+
+		// Save the updated registry
+		if err := registry.Save(); err != nil {
+			return fmt.Errorf("failed to save project registry: %w", err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	projectCmd.AddCommand(projectSetCmd)
+}

--- a/cmd/session_create.go
+++ b/cmd/session_create.go
@@ -112,6 +112,19 @@ func runSessionCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Check if auto-pull is enabled for this project
+	if project != nil && project.AutoPullOnCreate {
+		fmt.Printf("Pulling latest changes from origin/%s...\n", project.DefaultBranch)
+		if err := session.PullFromOrigin(projectPath, project.DefaultBranch); err != nil {
+			// Only show warning for actual errors, not network issues
+			if strings.Contains(err.Error(), "uncommitted changes") {
+				return fmt.Errorf("cannot create session: %w", err)
+			}
+			// For other errors, just warn and continue
+			fmt.Printf("Warning: Could not pull from origin: %v\n", err)
+		}
+	}
+
 	// Allocate or validate ports
 	var portAllocation *session.PortAllocation
 

--- a/config/projects.go
+++ b/config/projects.go
@@ -11,10 +11,11 @@ import (
 
 // Project represents a registered project in devx
 type Project struct {
-	Name          string `json:"name"`
-	Path          string `json:"path"`
-	Description   string `json:"description,omitempty"`
-	DefaultBranch string `json:"default_branch,omitempty"`
+	Name             string `json:"name"`
+	Path             string `json:"path"`
+	Description      string `json:"description,omitempty"`
+	DefaultBranch    string `json:"default_branch,omitempty"`
+	AutoPullOnCreate bool   `json:"auto_pull_on_create,omitempty"`
 }
 
 // ProjectRegistry manages multiple projects


### PR DESCRIPTION
Automatically pull latest changes from origin when creating new sessions for projects with auto-pull enabled. This ensures sessions always start with the latest code without needing to exit the TUI.

Features:
- Add AutoPullOnCreate field to Project struct
- Add --auto-pull flag to 'devx project add' command
- Create 'devx project set' command to modify project settings
- Implement PullFromOrigin function with graceful error handling
- Integrate auto-pull into session creation flow for CLI and TUI

The feature handles network failures, uncommitted changes, and missing branches gracefully, continuing with session creation when pull isn't possible.

🤖 Generated with [Claude Code](https://claude.ai/code)