### PR TITLE
Fix hostname generation for sessions with slashes in branch names

### DIFF
--- a/caddy/health.go
+++ b/caddy/health.go
@@ -83,14 +83,17 @@ func CheckCaddyHealth(sessions map[string]*SessionInfo) (*HealthCheckResult, err
 			// Normalize service name for DNS compatibility
 			normalizedServiceName := NormalizeDNSName(serviceName)
 
+			// Sanitize session name for hostname compatibility
+			sanitizedSessionName := SanitizeHostname(sessionName)
+
 			// Generate expected route ID and hostname
-			routeID := fmt.Sprintf("sess-%s-%s", sessionName, normalizedServiceName)
-			hostname := fmt.Sprintf("%s-%s.localhost", sessionName, normalizedServiceName)
+			routeID := fmt.Sprintf("sess-%s-%s", sanitizedSessionName, normalizedServiceName)
+			hostname := fmt.Sprintf("%s-%s.localhost", sanitizedSessionName, normalizedServiceName)
 
 			// Handle project prefixes if present
 			if sessionInfo.ProjectAlias != "" {
-				routeID = fmt.Sprintf("sess-%s-%s-%s", sessionInfo.ProjectAlias, sessionName, normalizedServiceName)
-				hostname = fmt.Sprintf("%s-%s-%s.localhost", sessionInfo.ProjectAlias, sessionName, normalizedServiceName)
+				routeID = fmt.Sprintf("sess-%s-%s-%s", sessionInfo.ProjectAlias, sanitizedSessionName, normalizedServiceName)
+				hostname = fmt.Sprintf("%s-%s-%s.localhost", sessionInfo.ProjectAlias, sanitizedSessionName, normalizedServiceName)
 			}
 
 			status := RouteStatus{

--- a/caddy/routes_test.go
+++ b/caddy/routes_test.go
@@ -76,6 +76,77 @@ func TestGetServiceMapping(t *testing.T) {
 	}
 }
 
+func TestSanitizeHostname(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Basic cases
+		{"simple", "simple"},
+		{"Simple-Case", "simple-case"},
+		{"UPPERCASE", "uppercase"},
+
+		// Slash handling (the main issue)
+		{"codex/add-ui-for-prompt-presets-in-frontend", "codex-add-ui-for-prompt-presets-in-frontend"},
+		{"feature/user-auth", "feature-user-auth"},
+		{"fix/api/endpoint", "fix-api-endpoint"},
+
+		// Multiple slashes
+		{"deep/nested/branch/name", "deep-nested-branch-name"},
+
+		// Underscore handling
+		{"branch_with_underscores", "branch-with-underscores"},
+		{"mix_of/slash_and_underscore", "mix-of-slash-and-underscore"},
+
+		// Special characters
+		{"branch.with.dots", "branch-with-dots"},
+		{"branch@with#special$chars", "branch-with-special-chars"},
+		{"branch with spaces", "branch-with-spaces"},
+
+		// Edge cases
+		{"", ""},
+		{"---multiple---hyphens---", "multiple-hyphens"},
+		{"-leading-and-trailing-", "leading-and-trailing"},
+		{"123-numeric-456", "123-numeric-456"},
+
+		// Complex real-world examples
+		{"feature/auth/oauth2-integration", "feature-auth-oauth2-integration"},
+		{"hotfix/payment_processing/stripe_api", "hotfix-payment-processing-stripe-api"},
+	}
+
+	for _, test := range tests {
+		result := SanitizeHostname(test.input)
+		if result != test.expected {
+			t.Errorf("SanitizeHostname(%q) = %q, expected %q",
+				test.input, result, test.expected)
+		}
+	}
+}
+
+func TestNormalizeDNSName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", "simple"},
+		{"UPPERCASE", "uppercase"},
+		{"with_underscores", "with-underscores"},
+		{"with spaces", "with-spaces"},
+		{"with@special#chars", "with-special-chars"},
+		{"", ""},
+		{"---multiple---hyphens---", "multiple-hyphens"},
+		{"-leading-and-trailing-", "leading-and-trailing"},
+	}
+
+	for _, test := range tests {
+		result := NormalizeDNSName(test.input)
+		if result != test.expected {
+			t.Errorf("NormalizeDNSName(%q) = %q, expected %q",
+				test.input, result, test.expected)
+		}
+	}
+}
+
 func contains(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {


### PR DESCRIPTION
## Summary
- Fix hostname generation for branch names containing slashes (e.g., `codex/add-ui-for-prompt-presets-in-frontend`)
- Add `SanitizeHostname()` function to convert session names to hostname-compatible format
- Update hostname generation across routes.go, provisioning.go, and health.go
- Maintain backward compatibility for route deletion

## Problem
Branch names with slashes were breaking Caddy hostname generation, creating invalid DNS names like `codex/add-ui-for-prompt-presets-in-frontend-ui.localhost` which don't resolve properly.

## Solution
- Created dedicated hostname sanitization function that converts slashes, underscores, and special characters to hyphens
- Applied sanitization to all hostname generation points
- Added comprehensive tests covering various problematic characters
- Enhanced route deletion to handle both original and sanitized session names

## Test plan
- [x] Added comprehensive unit tests for hostname sanitization
- [x] Verified existing tests still pass
- [x] Ran pre-commit checks (gofmt, go vet, go test, go mod tidy)
- [x] Tested with real branch names containing slashes

🤖 Generated with [Claude Code](https://claude.ai/code)