### PR TITLE
Fix environment variable hostname sanitization for sessions with spec…

### DIFF
--- a/cmd/session_create.go
+++ b/cmd/session_create.go
@@ -228,10 +228,12 @@ func runSessionCreate(cmd *cobra.Command, args []string) error {
 		for serviceName := range routes {
 			// Use the DNS-normalized service name for the hostname
 			dnsServiceName := caddy.NormalizeDNSName(serviceName)
+			// Sanitize session name for hostname compatibility
+			sanitizedSessionName := caddy.SanitizeHostname(name)
 			if projectAlias != "" {
-				hostnames[serviceName] = fmt.Sprintf("%s-%s-%s.localhost", projectAlias, name, dnsServiceName)
+				hostnames[serviceName] = fmt.Sprintf("%s-%s-%s.localhost", projectAlias, sanitizedSessionName, dnsServiceName)
 			} else {
-				hostnames[serviceName] = fmt.Sprintf("%s-%s.localhost", name, dnsServiceName)
+				hostnames[serviceName] = fmt.Sprintf("%s-%s.localhost", sanitizedSessionName, dnsServiceName)
 			}
 		}
 	}

--- a/session/cleanup.go
+++ b/session/cleanup.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+
+	"github.com/jfox85/devx/caddy"
 )
 
 // RunCleanupCommand executes the configured cleanup command with session environment variables
@@ -58,7 +60,9 @@ func prepareCleanupEnvironment(sess *Session) []string {
 
 			// Reconstruct the hostname from the route ID
 			// Route IDs are typically in format: "session-service.localhost"
-			hostname := fmt.Sprintf("https://%s-%s.localhost", sess.Name, strings.ToLower(serviceName))
+			// Sanitize session name for hostname compatibility
+			sanitizedSessionName := caddy.SanitizeHostname(sess.Name)
+			hostname := fmt.Sprintf("https://%s-%s.localhost", sanitizedSessionName, strings.ToLower(serviceName))
 			env = append(env, fmt.Sprintf("%s=%s", hostVar, hostname))
 		}
 	}

--- a/tui/model.go
+++ b/tui/model.go
@@ -1893,10 +1893,12 @@ func (m *model) loadHostnames(sessionName string) tea.Cmd {
 				for serviceName := range sess.Routes {
 					// Generate hostname based on project and session info
 					dnsServiceName := caddy.NormalizeDNSName(serviceName)
+					// Sanitize session name for hostname compatibility
+					sanitizedSessionName := caddy.SanitizeHostname(sess.Name)
 					if sess.ProjectAlias != "" {
-						hostnames = append(hostnames, fmt.Sprintf("%s-%s-%s", sess.ProjectAlias, sess.Name, dnsServiceName))
+						hostnames = append(hostnames, fmt.Sprintf("%s-%s-%s", sess.ProjectAlias, sanitizedSessionName, dnsServiceName))
 					} else {
-						hostnames = append(hostnames, fmt.Sprintf("%s-%s", sess.Name, dnsServiceName))
+						hostnames = append(hostnames, fmt.Sprintf("%s-%s", sanitizedSessionName, dnsServiceName))
 					}
 				}
 				sort.Strings(hostnames)
@@ -1915,10 +1917,12 @@ func (m *model) loadHostnames(sessionName string) tea.Cmd {
 				for serviceName := range sess.Routes {
 					// Generate hostname based on project and session info
 					dnsServiceName := caddy.NormalizeDNSName(serviceName)
+					// Sanitize session name for hostname compatibility
+					sanitizedSessionName := caddy.SanitizeHostname(sess.Name)
 					if sess.ProjectAlias != "" {
-						hostnameSet[fmt.Sprintf("%s-%s-%s", sess.ProjectAlias, sess.Name, dnsServiceName)] = true
+						hostnameSet[fmt.Sprintf("%s-%s-%s", sess.ProjectAlias, sanitizedSessionName, dnsServiceName)] = true
 					} else {
-						hostnameSet[fmt.Sprintf("%s-%s", sess.Name, dnsServiceName)] = true
+						hostnameSet[fmt.Sprintf("%s-%s", sanitizedSessionName, dnsServiceName)] = true
 					}
 				}
 			}


### PR DESCRIPTION
…ial characters

Ensures consistency between Caddy routes and environment variables by using caddy.SanitizeHostname() in hostname generation. Sessions like "codex/rename- voice-evolution-to-smartstyle" now correctly generate sanitized hostnames like "codex-rename-voice-evolution-to-smartstyle-ui.localhost" in both places.

Changes:
- cmd/session_create.go: Sanitize session name in environment hostname generation
- session/cleanup.go: Sanitize session name in cleanup hostname generation
- tui/model.go: Sanitize session name in TUI hostname display

🤖 Generated with [Claude Code](https://claude.ai/code)