### PR TITLE
Remove duplicate release creation from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [ main, master, 'jf-*' ]
-    tags: [ 'v*' ]
   pull_request:
     branches: [ main, master ]
 
@@ -135,12 +134,3 @@ jobs:
         name: binaries
         path: dist/*
         retention-days: 7
-    
-    - name: Create Release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: softprops/action-gh-release@v2
-      with:
-        files: dist/*
-        draft: false
-        prerelease: false
-        generate_release_notes: true


### PR DESCRIPTION
The ci.yml workflow was conflicting with the dedicated release.yml workflow, causing permission errors when both tried to create releases on tag pushes. Now release.yml (with GoReleaser) is the sole owner of release creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI to run only on non-tag pushes.
  * Removed automated release creation from tag events.
  * Maintained artifact retention at 7 days.
  * No user-facing functionality changes; app behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->