### PR TITLE
Fix mobile web terminal scrollback and add pane viewer

### DIFF
--- a/.devx/session.yaml.tmpl
+++ b/.devx/session.yaml.tmpl
@@ -4,7 +4,8 @@ suppress_history: false
 options:
   base-index: 1
   automatic-rename: "off"
-  mouse: on
+  mouse: {{defaultTmuxMouse}}
+  history-limit: {{defaultTmuxHistoryLimit}}
   status: on
   status-interval: 5
   status-left-length: 60

--- a/session/tmuxp.go
+++ b/session/tmuxp.go
@@ -13,8 +13,14 @@ import (
 	"github.com/jfox85/devx/config"
 )
 
+const DefaultTmuxMouse = "off"
+const DefaultTmuxHistoryLimit = 50000
+
 const tmuxpTemplate = `session_name: {{.Name}}
 start_directory: {{.Path}}
+options:
+  mouse: {{defaultTmuxMouse}}
+  history-limit: {{defaultTmuxHistoryLimit}}
 windows:
   - window_name: editor
     layout: tiled
@@ -85,6 +91,12 @@ func GenerateTmuxpConfig(worktreePath string, data TmuxpData, projectPath string
 			// e.g., "frontend" -> "FRONTEND_EXTERNAL_HOST"
 			upper := strings.ToUpper(serviceName)
 			return strings.ReplaceAll(upper, "-", "_") + "_EXTERNAL_HOST"
+		},
+		"defaultTmuxMouse": func() string {
+			return DefaultTmuxMouse
+		},
+		"defaultTmuxHistoryLimit": func() int {
+			return DefaultTmuxHistoryLimit
 		},
 	}
 

--- a/session/tmuxp_test.go
+++ b/session/tmuxp_test.go
@@ -23,6 +23,8 @@ func TestGenerateTmuxpConfig(t *testing.T) {
 			os.Setenv("DEVX_TMUXP_TEMPLATE", oldTemplate)
 		}
 	}()
+	// Prevent host-global templates from affecting this test.
+	t.Setenv("HOME", tmpDir)
 
 	// Test data
 	data := TmuxpData{
@@ -56,6 +58,14 @@ func TestGenerateTmuxpConfig(t *testing.T) {
 	// Verify start directory
 	if !strings.Contains(configStr, "start_directory: "+tmpDir) {
 		t.Error("config should contain start directory")
+	}
+
+	// Verify default mobile-friendly tmux options are present.
+	if !strings.Contains(configStr, "mouse: off") {
+		t.Error("config should disable tmux mouse mode by default")
+	}
+	if !strings.Contains(configStr, "history-limit: 50000") {
+		t.Error("config should set a generous history limit")
 	}
 
 	// Verify at least one window exists

--- a/web/api.go
+++ b/web/api.go
@@ -6,7 +6,9 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"mime"
 	"net/http"
@@ -33,7 +35,10 @@ func registerAPIRoutes(mux *http.ServeMux) {
 	// Session name passed as query param (?name=...) to avoid path-segment
 	// splitting on session names that contain slashes.
 	mux.HandleFunc("GET /api/windows", handleListWindows)
+	mux.HandleFunc("GET /api/active-pane", handleActivePane)
 	mux.HandleFunc("GET /api/pane-content", handlePaneContent)
+	mux.HandleFunc("GET /api/pane-content.txt", handlePaneContentText)
+	mux.HandleFunc("GET /api/pane-content/view", handlePaneContentView)
 	mux.HandleFunc("GET /api/projects", handleListProjects)
 	mux.HandleFunc("POST /api/switch-window", handleSwitchWindow)
 	mux.HandleFunc("POST /api/send-keys", handleSendKeys)
@@ -44,6 +49,38 @@ func registerAPIRoutes(mux *http.ServeMux) {
 	// Serve uploaded files — auth enforced via /uploads/ prefix in authMiddleware.
 	mux.HandleFunc("GET /uploads/", handleServeUpload)
 }
+
+var execTmuxOutput = func(args ...string) ([]byte, error) {
+	return exec.Command("tmux", args...).Output()
+}
+
+var execTmuxRun = func(args ...string) error {
+	return exec.Command("tmux", args...).Run()
+}
+
+var paneContentViewTmpl = template.Must(template.New("pane-content-view").Parse(`<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>devx pane output</title>
+  <style>
+    body{margin:0;background:#020617;color:#e5eefc;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+    header{position:sticky;top:0;background:#0f172a;border-bottom:1px solid #1e293b;padding:12px 14px}
+    h1{margin:0;font-size:18px}
+    p{margin:4px 0 0;color:#94a3b8;font-size:12px}
+    pre{margin:0;padding:14px;font-size:14px;line-height:1.45;white-space:pre;overflow:auto;-webkit-overflow-scrolling:touch}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Full Output</h1>
+    <p>Session: {{.Name}} · Target: {{.Target}}</p>
+  </header>
+  <pre id="pane-output">{{.Content}}</pre>
+  <script>(function(){function scrollToBottom(){window.scrollTo(0, document.documentElement.scrollHeight || document.body.scrollHeight);}if(document.readyState==='complete'){scrollToBottom();}else{window.addEventListener('load', scrollToBottom, {once:true});}requestAnimationFrame(scrollToBottom);setTimeout(scrollToBottom, 50);})();</script>
+</body>
+</html>`))
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -332,10 +369,18 @@ func (s *Server) handleFlagNotify(w http.ResponseWriter, r *http.Request) {
 // the browser viewport, not a terminal client that may be attached to the
 // base session.
 func resolveWebSession(name string) string {
-	if exec.Command("tmux", "has-session", "-t", "="+name+"-web").Run() == nil {
+	if execTmuxRun("has-session", "-t", "="+name+"-web") == nil {
 		return name + "-web"
 	}
 	return name
+}
+
+func exactTmuxSessionTarget(name string) string {
+	return "=" + resolveWebSession(name)
+}
+
+func exactTmuxWindowTarget(name, window string) string {
+	return exactTmuxSessionTarget(name) + ":" + window
 }
 
 // requireValidSession validates that name is a legal devx session name and
@@ -355,11 +400,18 @@ type windowInfo struct {
 	Active bool   `json:"active"`
 }
 
+type activePaneResponse struct {
+	Pane int `json:"pane"`
+}
+
 type paneContentResponse struct {
 	Content string `json:"content"`
 	Target  string `json:"target"`
 }
 
+const paneCaptureLines = session.DefaultTmuxHistoryLimit
+
+var errInvalidPane = errors.New("pane must be a numeric index")
 var ansiEscapePattern = regexp.MustCompile(`\x1b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[@-_])`)
 
 func stripANSI(s string) string {
@@ -367,14 +419,31 @@ func stripANSI(s string) string {
 }
 
 func paneCaptureTarget(name, pane string) (string, error) {
-	target := resolveWebSession(name)
+	target := exactTmuxSessionTarget(name)
 	if pane == "" {
 		return target, nil
 	}
 	if _, err := strconv.Atoi(pane); err != nil {
-		return "", fmt.Errorf("pane must be a numeric index")
+		return "", errInvalidPane
 	}
 	return target + ":." + pane, nil
+}
+
+func capturePaneContent(name, pane string) (paneContentResponse, error) {
+	target, err := paneCaptureTarget(name, pane)
+	if err != nil {
+		return paneContentResponse{}, err
+	}
+
+	out, err := execTmuxOutput("capture-pane", "-t", target, "-p", "-S", fmt.Sprintf("-%d", paneCaptureLines))
+	if err != nil {
+		return paneContentResponse{}, err
+	}
+
+	return paneContentResponse{
+		Content: strings.TrimRight(stripANSI(string(out)), "\n"),
+		Target:  target,
+	}, nil
 }
 
 // handleListWindows returns the tmux windows for the session given by ?name=.
@@ -394,8 +463,8 @@ func handleListWindows(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Use tab as delimiter so window names that contain spaces are preserved.
-	out, err := exec.Command("tmux", "list-windows", "-t", resolveWebSession(name), "-F",
-		"#{window_index}\t#{window_name}\t#{window_active}").Output()
+	out, err := execTmuxOutput("list-windows", "-t", exactTmuxSessionTarget(name), "-F",
+		"#{window_index}\t#{window_name}\t#{window_active}")
 	if err != nil {
 		// tmux session not running — return empty list rather than an error.
 		writeJSON(w, http.StatusOK, map[string]any{"windows": []windowInfo{}})
@@ -424,6 +493,29 @@ func handleListWindows(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"windows": windows})
 }
 
+func handleActivePane(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name query param required"})
+		return
+	}
+	if !requireValidSession(w, name) {
+		return
+	}
+
+	out, err := execTmuxOutput("display-message", "-t", exactTmuxSessionTarget(name), "-p", "#{pane_index}")
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to resolve active pane"})
+		return
+	}
+	pane, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to resolve active pane"})
+		return
+	}
+	writeJSON(w, http.StatusOK, activePaneResponse{Pane: pane})
+}
+
 // handlePaneContent captures recent scrollback from the active pane in the
 // web-facing tmux session. Optional ?pane=<index> selects a specific pane in
 // the active window; otherwise tmux uses the active pane for the target.
@@ -437,22 +529,78 @@ func handlePaneContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	target, err := paneCaptureTarget(name, r.URL.Query().Get("pane"))
+	resp, status, err := loadPaneContentResponse(name, r.URL.Query().Get("pane"))
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, status, map[string]string{"error": err.Error()})
 		return
 	}
 
-	out, err := exec.Command("tmux", "capture-pane", "-t", target, "-p", "-S", "-5000").Output()
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func loadPaneContentResponse(name, pane string) (paneContentResponse, int, error) {
+	resp, err := capturePaneContent(name, pane)
+	if err == nil {
+		return resp, http.StatusOK, nil
+	}
+	if errors.Is(err, errInvalidPane) {
+		return paneContentResponse{}, http.StatusBadRequest, err
+	}
+	return paneContentResponse{}, http.StatusInternalServerError, fmt.Errorf("failed to capture pane content")
+}
+
+func handlePaneContentText(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		http.Error(w, "name query param required", http.StatusBadRequest)
+		return
+	}
+	if !session.IsValidSessionName(name) {
+		http.Error(w, "invalid session name", http.StatusBadRequest)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, paneContentResponse{
-		Content: strings.TrimRight(stripANSI(string(out)), "\n"),
-		Target:  target,
-	})
+	resp, status, err := loadPaneContentResponse(name, r.URL.Query().Get("pane"))
+	if err != nil {
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = io.WriteString(w, resp.Content)
+}
+
+func handlePaneContentView(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		http.Error(w, "name query param required", http.StatusBadRequest)
+		return
+	}
+	if !session.IsValidSessionName(name) {
+		http.Error(w, "invalid session name", http.StatusBadRequest)
+		return
+	}
+
+	resp, status, err := loadPaneContentResponse(name, r.URL.Query().Get("pane"))
+	if err != nil {
+		http.Error(w, err.Error(), status)
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := paneContentViewTmpl.Execute(w, struct {
+		Name    string
+		Target  string
+		Content string
+	}{
+		Name:    name,
+		Target:  resp.Target,
+		Content: resp.Content,
+	}); err != nil {
+		http.Error(w, "failed to render pane content", http.StatusInternalServerError)
+	}
 }
 
 // handleListProjects returns the sorted list of project aliases from the registry.
@@ -489,7 +637,7 @@ func handleSwitchWindow(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "window must be a numeric index"})
 		return
 	}
-	if err := exec.Command("tmux", "select-window", "-t", resolveWebSession(name)+":"+window).Run(); err != nil {
+	if err := execTmuxRun("select-window", "-t", exactTmuxWindowTarget(name, window)); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -513,9 +661,9 @@ func handleRefreshTerminal(w http.ResponseWriter, r *http.Request) {
 	if !requireValidSession(w, name) {
 		return
 	}
-	webSess := resolveWebSession(name)
-	_ = exec.Command("tmux", "refresh-client", "-t", webSess).Run()
-	resizeWindowToClient(webSess)
+	target := exactTmuxSessionTarget(name)
+	_ = execTmuxRun("refresh-client", "-t", target)
+	resizeWindowToClient(target)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -540,7 +688,7 @@ func handleRefreshTerminal(w http.ResponseWriter, r *http.Request) {
 // session's stale size.
 func resizeWindowToClient(target string) {
 	// client_activity is a Unix timestamp; pick the client with the highest value.
-	out, err := exec.Command("tmux", "list-clients", "-t", target, "-F", "#{client_activity} #{client_width} #{client_height}").Output()
+	out, err := execTmuxOutput("list-clients", "-t", target, "-F", "#{client_activity} #{client_width} #{client_height}")
 	if err != nil || len(out) == 0 {
 		return
 	}
@@ -566,9 +714,9 @@ func resizeWindowToClient(target string) {
 	if latestW <= 0 || latestH <= 0 {
 		return
 	}
-	_ = exec.Command("tmux", "resize-window", "-t", target,
+	_ = execTmuxRun("resize-window", "-t", target,
 		"-x", strconv.Itoa(latestW),
-		"-y", strconv.Itoa(latestH)).Run()
+		"-y", strconv.Itoa(latestH))
 }
 
 // handleSendKeys runs `tmux send-keys -t session key`, delivering the key to the
@@ -595,13 +743,13 @@ func handleSendKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	target := resolveWebSession(name)
+	target := exactTmuxSessionTarget(name)
 	mode := r.URL.Query().Get("mode")
 
 	if mode == "literal" {
 		// Send the text verbatim — used for inserting file paths into the active pane.
 		// -l disables special-key interpretation so spaces are not split by tmux.
-		if err := exec.Command("tmux", "send-keys", "-t", target, "-l", "--", keys).Run(); err != nil {
+		if err := execTmuxRun("send-keys", "-t", target, "-l", "--", keys); err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
@@ -632,7 +780,7 @@ func handleSendKeys(w http.ResponseWriter, r *http.Request) {
 	// and a terminal client are on different windows.
 	// Use -- to ensure no key token is misinterpreted as a tmux send-keys flag.
 	args := append([]string{"send-keys", "-t", target, "--"}, keyList...)
-	if err := exec.Command("tmux", args...).Run(); err != nil {
+	if err := execTmuxRun(args...); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/web/api_test.go
+++ b/web/api_test.go
@@ -2,9 +2,14 @@ package web
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/jfox85/devx/session"
 )
 
 func TestGetSessionsReturnsJSON(t *testing.T) {
@@ -39,4 +44,296 @@ func TestGetHealthReturnsOK(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", w.Code)
 	}
+}
+
+func TestPaneCaptureTargetUsesExactMatchForSlashSessionNames(t *testing.T) {
+	origRun := execTmuxRun
+	execTmuxRun = func(args ...string) error { return nil }
+	defer func() { execTmuxRun = origRun }()
+
+	target, err := paneCaptureTarget("feature/foo", "2")
+	if err != nil {
+		t.Fatalf("paneCaptureTarget returned error: %v", err)
+	}
+	if want := "=feature/foo-web:.2"; target != want {
+		t.Fatalf("expected %q, got %q", want, target)
+	}
+}
+
+func TestPaneCaptureTargetRejectsNonNumericPane(t *testing.T) {
+	if _, err := paneCaptureTarget("feature/foo", "abc"); err == nil {
+		t.Fatal("expected error for non-numeric pane")
+	}
+}
+
+func TestPaneCaptureLinesMatchesTmuxHistoryLimit(t *testing.T) {
+	if paneCaptureLines != session.DefaultTmuxHistoryLimit {
+		t.Fatalf("pane capture lines = %d, want %d", paneCaptureLines, session.DefaultTmuxHistoryLimit)
+	}
+}
+
+func TestActivePaneReturnsPaneIndex(t *testing.T) {
+	withStubbedTmux(t,
+		func(args ...string) error { return errors.New("no web session") },
+		func(args ...string) ([]byte, error) {
+			if got, want := strings.Join(args, " "), "display-message -t =jf-add-web -p #{pane_index}"; got != want {
+				t.Fatalf("unexpected tmux args: %q != %q", got, want)
+			}
+			return []byte("2\n"), nil
+		})
+
+	resp := authedRequest(t, "GET", "/api/active-pane?name=jf-add-web", nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var body activePaneResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if body.Pane != 2 {
+		t.Fatalf("expected pane 2, got %d", body.Pane)
+	}
+}
+
+func TestPaneContentEndpointsRequireAuth(t *testing.T) {
+	mux := http.NewServeMux()
+	registerAPIRoutes(mux)
+	handler := authMiddleware("test-secret", mux)
+
+	req := httptest.NewRequest("GET", "/api/pane-content/view?name=jf-add-web", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestPaneContentJSONReturnsCapturedContent(t *testing.T) {
+	withStubbedTmux(t,
+		func(args ...string) error {
+			if len(args) >= 1 && args[0] == "has-session" {
+				return nil
+			}
+			return nil
+		},
+		func(args ...string) ([]byte, error) {
+			if got, want := strings.Join(args, " "), "capture-pane -t =jf-add-web-web -p -S -50000"; got != want {
+				t.Fatalf("unexpected tmux args: %q != %q", got, want)
+			}
+			return []byte("line 1\nline 2\n"), nil
+		})
+
+	resp := authedRequest(t, "GET", "/api/pane-content?name=jf-add-web", nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if ct := resp.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+
+	var body paneContentResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if body.Content != "line 1\nline 2" {
+		t.Fatalf("unexpected content %q", body.Content)
+	}
+	if body.Target != "=jf-add-web-web" {
+		t.Fatalf("unexpected target %q", body.Target)
+	}
+}
+
+func TestPaneContentJSONRejectsInvalidPane(t *testing.T) {
+	resp := authedRequest(t, "GET", "/api/pane-content?name=jf-add-web&pane=abc", nil)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.Code)
+	}
+	if !strings.Contains(resp.Body.String(), "pane must be a numeric index") {
+		t.Fatalf("unexpected body: %s", resp.Body.String())
+	}
+}
+
+func TestListWindowsUsesExactTargetForSlashSessionNames(t *testing.T) {
+	withStubbedTmux(t,
+		func(args ...string) error { return errors.New("no web session") },
+		func(args ...string) ([]byte, error) {
+			if got, want := strings.Join(args, " "), "list-windows -t =feature/foo -F #{window_index}\t#{window_name}\t#{window_active}"; got != want {
+				t.Fatalf("unexpected tmux args: %q != %q", got, want)
+			}
+			return []byte("1\teditor\t1\n"), nil
+		})
+
+	resp := authedRequest(t, "GET", "/api/windows?name=feature%2Ffoo", nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestSwitchWindowUsesExactTargetForSlashSessionNames(t *testing.T) {
+	withStubbedTmux(t,
+		func(args ...string) error {
+			got := strings.Join(args, " ")
+			switch got {
+			case "has-session -t =feature/foo-web":
+				return errors.New("no web session")
+			case "select-window -t =feature/foo:3":
+				return nil
+			default:
+				t.Fatalf("unexpected tmux args: %q", got)
+				return nil
+			}
+		},
+		func(args ...string) ([]byte, error) { return nil, errors.New("unexpected output call") })
+
+	resp := authedRequest(t, "POST", "/api/switch-window?name=feature%2Ffoo&window=3", nil)
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestRefreshUsesExactTargetForSlashSessionNames(t *testing.T) {
+	seenRefresh := false
+	seenListClients := false
+	seenResize := false
+	withStubbedTmux(t,
+		func(args ...string) error {
+			got := strings.Join(args, " ")
+			switch got {
+			case "has-session -t =feature/foo-web":
+				return errors.New("no web session")
+			case "refresh-client -t =feature/foo":
+				seenRefresh = true
+				return nil
+			case "resize-window -t =feature/foo -x 120 -y 42":
+				seenResize = true
+				return nil
+			default:
+				t.Fatalf("unexpected tmux run args: %q", got)
+				return nil
+			}
+		},
+		func(args ...string) ([]byte, error) {
+			got := strings.Join(args, " ")
+			if got != "list-clients -t =feature/foo -F #{client_activity} #{client_width} #{client_height}" {
+				t.Fatalf("unexpected tmux output args: %q", got)
+			}
+			seenListClients = true
+			return []byte("123 120 42\n"), nil
+		})
+
+	resp := authedRequest(t, "POST", "/api/refresh?name=feature%2Ffoo", nil)
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !(seenRefresh && seenListClients && seenResize) {
+		t.Fatalf("expected refresh, list-clients, and resize-window to run; got refresh=%v list=%v resize=%v", seenRefresh, seenListClients, seenResize)
+	}
+}
+
+func TestSendLiteralUsesExactTargetForSlashSessionNames(t *testing.T) {
+	withStubbedTmux(t,
+		func(args ...string) error {
+			got := strings.Join(args, " ")
+			switch got {
+			case "has-session -t =feature/foo-web":
+				return errors.New("no web session")
+			case "send-keys -t =feature/foo -l -- hello world":
+				return nil
+			default:
+				t.Fatalf("unexpected tmux args: %q", got)
+				return nil
+			}
+		},
+		func(args ...string) ([]byte, error) { return nil, errors.New("unexpected output call") })
+
+	resp := authedRequest(t, "POST", "/api/send-keys?mode=literal&name=feature%2Ffoo&keys=hello%20world", nil)
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestPaneContentTextReturnsPlainText(t *testing.T) {
+	withStubbedTmux(t,
+		func(args ...string) error { return errors.New("no web session") },
+		func(args ...string) ([]byte, error) {
+			if got, want := strings.Join(args, " "), "capture-pane -t =jf-add-web -p -S -50000"; got != want {
+				t.Fatalf("unexpected tmux args: %q != %q", got, want)
+			}
+			return []byte("plain output\n"), nil
+		})
+
+	resp := authedRequest(t, "GET", "/api/pane-content.txt?name=jf-add-web", nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if ct := resp.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("expected text/plain content type, got %q", ct)
+	}
+	if body := resp.Body.String(); body != "plain output" {
+		t.Fatalf("unexpected body %q", body)
+	}
+}
+
+func TestPaneContentViewEscapesHTML(t *testing.T) {
+	withStubbedTmux(t,
+		func(args ...string) error { return nil },
+		func(args ...string) ([]byte, error) {
+			return []byte("<script>alert('xss')</script>\n& raw"), nil
+		})
+
+	resp := authedRequest(t, "GET", "/api/pane-content/view?name=jf-add-web", nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if ct := resp.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("expected text/html content type, got %q", ct)
+	}
+	body := resp.Body.String()
+	if strings.Contains(body, "<script>alert('xss')</script>") {
+		t.Fatalf("response should escape pane content, got %s", body)
+	}
+	if !strings.Contains(body, "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;") {
+		t.Fatalf("expected escaped script tag in response, got %s", body)
+	}
+	if !strings.Contains(body, "requestAnimationFrame(scrollToBottom)") {
+		t.Fatalf("expected auto-scroll script in html response")
+	}
+}
+
+func TestPaneContentViewInvalidSessionReturnsPlainError(t *testing.T) {
+	resp := authedRequest(t, "GET", "/api/pane-content/view?name=<bad>", nil)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.Code)
+	}
+	if ct := resp.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("expected text/plain content type, got %q", ct)
+	}
+	if !strings.Contains(resp.Body.String(), "invalid session name") {
+		t.Fatalf("unexpected body: %s", resp.Body.String())
+	}
+}
+
+func withStubbedTmux(t *testing.T, run func(args ...string) error, output func(args ...string) ([]byte, error)) {
+	t.Helper()
+	origRun := execTmuxRun
+	origOutput := execTmuxOutput
+	execTmuxRun = run
+	execTmuxOutput = output
+	t.Cleanup(func() {
+		execTmuxRun = origRun
+		execTmuxOutput = origOutput
+	})
+}
+
+func authedRequest(t *testing.T, method, path string, body io.Reader) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	registerAPIRoutes(mux)
+	handler := authMiddleware("test-secret", mux)
+	req := httptest.NewRequest(method, path, body)
+	req.Header.Set("Authorization", "Bearer test-secret")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
 }

--- a/web/app/src/api.js
+++ b/web/app/src/api.js
@@ -102,6 +102,12 @@ export async function listWindows(sessionName) {
   return data.windows || []
 }
 
+export async function getActivePane(sessionName) {
+  const res = await apiFetch('/active-pane?name=' + encodeURIComponent(sessionName))
+  const data = await res.json()
+  return data.pane
+}
+
 export async function switchWindow(sessionName, windowIndex) {
   await apiFetch(
     '/switch-window?name=' + encodeURIComponent(sessionName) + '&window=' + windowIndex,

--- a/web/app/src/lib/Terminal.svelte
+++ b/web/app/src/lib/Terminal.svelte
@@ -147,6 +147,9 @@
   const FITADDON_SETTLE_MS     = 200   // time for FitAddon → ioctl to propagate
 
   async function openPaneViewer() {
+    // Open synchronously while still inside the click gesture context so
+    // mobile browsers do not treat it as a blocked popup after awaiting.
+    const viewerWindow = window.open('', '_blank')
     const params = new URLSearchParams({ name: session.name })
     try {
       const pane = await getActivePane(session.name)
@@ -154,7 +157,12 @@
     } catch {
       // Fall back to tmux's current active pane if the lookup fails.
     }
-    window.open(`/api/pane-content/view?${params.toString()}`, '_blank', 'noopener,noreferrer')
+    const url = `/api/pane-content/view?${params.toString()}`
+    if (viewerWindow) {
+      viewerWindow.location.replace(url)
+    } else {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    }
   }
 
   // When the iframe finishes loading, wait for xterm.js to fully initialise

--- a/web/app/src/lib/Terminal.svelte
+++ b/web/app/src/lib/Terminal.svelte
@@ -1,7 +1,7 @@
 <!-- web/app/src/lib/Terminal.svelte -->
 <script>
   import { onMount, onDestroy } from 'svelte'
-  import { listWindows, switchWindow as apiSwitchWindow, sendKeys as apiSendKeys, sendLiteral, refreshTerminal, uploadImage } from '../api.js'
+  import { getActivePane, listWindows, switchWindow as apiSwitchWindow, sendKeys as apiSendKeys, sendLiteral, refreshTerminal, uploadImage } from '../api.js'
   import SoftKeybar from './SoftKeybar.svelte'
   import ImageToast from './ImageToast.svelte'
 
@@ -146,6 +146,17 @@
   const XTERM_POLL_INTERVAL_MS = 100   // polling interval while waiting
   const FITADDON_SETTLE_MS     = 200   // time for FitAddon → ioctl to propagate
 
+  async function openPaneViewer() {
+    const params = new URLSearchParams({ name: session.name })
+    try {
+      const pane = await getActivePane(session.name)
+      if (pane != null && !Number.isNaN(Number(pane))) params.set('pane', String(pane))
+    } catch {
+      // Fall back to tmux's current active pane if the lookup fails.
+    }
+    window.open(`/api/pane-content/view?${params.toString()}`, '_blank', 'noopener,noreferrer')
+  }
+
   // When the iframe finishes loading, wait for xterm.js to fully initialise
   // (indicated by the helper textarea appearing), then:
   //   1. Call term.fit() → FitAddon re-measures the element and sends the
@@ -163,6 +174,24 @@
       link.rel = 'stylesheet'
       link.href = '/nerd-font.css'
       iframeEl.contentDocument.head.appendChild(link)
+
+      const touchStyle = iframeEl.contentDocument.createElement('style')
+      touchStyle.textContent = `
+        html, body {
+          height: 100%;
+          margin: 0;
+          overflow: hidden;
+          overscroll-behavior: none;
+        }
+        .xterm, .xterm-viewport {
+          touch-action: pan-y !important;
+        }
+        .xterm-viewport {
+          -webkit-overflow-scrolling: touch !important;
+          overscroll-behavior-y: contain;
+        }
+      `
+      iframeEl.contentDocument.head.appendChild(touchStyle)
       // Wait for the font to be ready before xterm starts measuring.
       await iframeEl.contentWindow.document.fonts.load('12px HackNerdFontMono')
     } catch { /* ignore cross-origin / not-yet-loaded */ }
@@ -448,6 +477,12 @@
         class="flex-1 flex items-center text-gray-500 font-mono text-xs truncate px-3 min-w-0 text-left"
       >{session.name}</button>
     {/if}
+
+    <button
+      on:click={openPaneViewer}
+      title="open full pane output in a new tab"
+      class="px-3 text-gray-500 hover:text-cyan-300 text-xs font-mono shrink-0 border-l border-[#1e2d4a] flex items-center justify-center transition-colors min-w-[58px]"
+    >[view]</button>
 
     <!-- Attach image button -->
     <button

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -6,8 +6,8 @@
     <link rel="preload" href="/HackNerdFontMono-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>devx</title>
-    <script type="module" crossorigin src="/assets/index-B9Ko4DoI.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-3BQ9riOS.css">
+    <script type="module" crossorigin src="/assets/index-B6K00WFD.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-C5NT_bhS.css">
   </head>
   <body style="margin:0;background:#0a0e1a">
     <div id="app"></div>

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -6,7 +6,7 @@
     <link rel="preload" href="/HackNerdFontMono-Regular.ttf" as="font" type="font/ttf" crossorigin="anonymous" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>devx</title>
-    <script type="module" crossorigin src="/assets/index-B6K00WFD.js"></script>
+    <script type="module" crossorigin src="/assets/index-D090mT2m.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-C5NT_bhS.css">
   </head>
   <body style="margin:0;background:#0a0e1a">

--- a/web/ttyd.go
+++ b/web/ttyd.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jfox85/devx/session"
 	getport "github.com/jsumners/go-getport"
 )
 
@@ -28,6 +29,20 @@ func newTtydManager() *ttydManager {
 }
 
 const ttydIdleTimeout = 30 * time.Second
+const ttydScrollbackLines = 5000
+
+func ttydArgs(sessionName string, port int) []string {
+	webSession := sessionName + "-web"
+	return []string{
+		"-p", fmt.Sprintf("%d", port),
+		"-i", "127.0.0.1", // bind to loopback only — not reachable from the network
+		"-W",
+		"--base-path", "/terminal/" + sessionName,
+		"-t", fmt.Sprintf("scrollback=%d", ttydScrollbackLines),
+		"-t", "fontFamily=HackNerdFontMono, monospace",
+		"tmux", "new-session", "-A", "-s", webSession, "-t", "=" + sessionName,
+	}
+}
 
 // startForSession returns the local port of the ttyd instance for the session,
 // starting one if not already running. cmdAndArgs overrides the default
@@ -72,16 +87,7 @@ func (m *ttydManager) startForSession(sessionName string, cmdAndArgs ...string) 
 		// "tmux attach" so the web client gets its own grouped session with
 		// independent sizing. This prevents the browser window dimensions from
 		// constraining the terminal session used by the real terminal client.
-		webSession := sessionName + "-web"
-		args := []string{
-			"-p", fmt.Sprintf("%d", port),
-			"-i", "127.0.0.1", // bind to loopback only — not reachable from the network
-			"-W",
-			"--base-path", "/terminal/" + sessionName,
-			"-t", "fontFamily=HackNerdFontMono, monospace",
-			"tmux", "new-session", "-A", "-s", webSession, "-t", sessionName,
-		}
-		cmd = exec.Command("ttyd", args...)
+		cmd = exec.Command("ttyd", ttydArgs(sessionName, port)...)
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -120,9 +126,31 @@ func (m *ttydManager) startForSession(sessionName string, cmdAndArgs ...string) 
 			_ = cmd.Process.Kill()
 			return 0, fmt.Errorf("ttyd did not start on port %d: %w", port, err)
 		}
+		applyMobileTmuxOptions(sessionName)
 	}
 
 	return port, nil
+}
+
+func applyMobileTmuxOptions(sessionName string) {
+	baseTarget := "=" + sessionName
+	_ = exec.Command("tmux", "set-option", "-t", baseTarget, "mouse", session.DefaultTmuxMouse).Run()
+	_ = exec.Command("tmux", "set-option", "-t", baseTarget, "history-limit", fmt.Sprintf("%d", session.DefaultTmuxHistoryLimit)).Run()
+
+	webTarget := "=" + sessionName + "-web"
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if exec.Command("tmux", "has-session", "-t", webTarget).Run() == nil {
+			mouseErr := exec.Command("tmux", "set-option", "-t", webTarget, "mouse", session.DefaultTmuxMouse).Run()
+			historyErr := exec.Command("tmux", "set-option", "-t", webTarget, "history-limit", fmt.Sprintf("%d", session.DefaultTmuxHistoryLimit)).Run()
+			if mouseErr != nil || historyErr != nil {
+				logWebError("applyMobileTmuxOptions(%q): web target update incomplete: mouse=%v history=%v", sessionName, mouseErr, historyErr)
+			}
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	logWebError("applyMobileTmuxOptions(%q): web target %q not available before timeout; history-limit is not retroactive for existing windows", sessionName, webTarget)
 }
 
 // waitForPort polls addr until it accepts a TCP connection or the timeout elapses.

--- a/web/ttyd_test.go
+++ b/web/ttyd_test.go
@@ -1,9 +1,72 @@
 package web
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestTtydArgsIncludeMobileScrollback(t *testing.T) {
+	args := ttydArgs("demo/session", 7681)
+	want := fmt.Sprintf("scrollback=%d", ttydScrollbackLines)
+	found := false
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "-t" && args[i+1] == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected ttyd args to include %q, got %v", want, args)
+	}
+}
+
+func TestTtydArgsUseExactMatchTarget(t *testing.T) {
+	args := ttydArgs("demo/session", 7681)
+	joined := fmt.Sprint(args)
+	if !containsSequence(args, []string{"tmux", "new-session", "-A", "-s", "demo/session-web", "-t", "=demo/session"}) {
+		t.Fatalf("expected exact-match tmux target in args, got %s", joined)
+	}
+}
+
+func TestApplyMobileTmuxOptionsAttemptsBaseAndWebTargets(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "tmux.log")
+	scriptPath := filepath.Join(tmpDir, "tmux")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "has-session" ] && [ "$4" = "=demo-web" ]; then
+  exit 0
+fi
+echo "$@" >> %s
+exit 0
+`, logPath)
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write tmux stub: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+
+	applyMobileTmuxOptions("demo")
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read tmux log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{
+		"set-option -t =demo mouse off",
+		"set-option -t =demo history-limit 50000",
+		"set-option -t =demo-web mouse off",
+		"set-option -t =demo-web history-limit 50000",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("expected tmux log to contain %q, got %s", want, log)
+		}
+	}
+}
 
 func TestTtydManagerStartStop(t *testing.T) {
 	m := newTtydManager()
@@ -31,4 +94,20 @@ func TestTtydManagerStartStop(t *testing.T) {
 
 	m.stopSession("test-session")
 	// Verify entry cleaned up (no panic, no port reuse issue)
+}
+
+func containsSequence(haystack, needle []string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }

--- a/web/ttyd_test.go
+++ b/web/ttyd_test.go
@@ -37,7 +37,7 @@ func TestApplyMobileTmuxOptionsAttemptsBaseAndWebTargets(t *testing.T) {
 	logPath := filepath.Join(tmpDir, "tmux.log")
 	scriptPath := filepath.Join(tmpDir, "tmux")
 	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "has-session" ] && [ "$4" = "=demo-web" ]; then
+if [ "$1" = "has-session" ] && [ "$2" = "-t" ] && [ "$3" = "=demo-web" ]; then
   exit 0
 fi
 echo "$@" >> %s


### PR DESCRIPTION
## Summary
- improve mobile web-terminal scrollback defaults for ttyd and tmux
- add slash-safe tmux targeting and pane-content endpoints/tests
- open full output in a standalone viewer tab that auto-scrolls to the bottom

## Testing
- go vet ./...
- go test -race ./...
- cd web/app && npm run build
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pane viewer interface to display terminal pane content in a dedicated modal or tab.
  * Introduced API endpoints for retrieving active pane information and pane content (available in JSON and plain text formats).
  * Made tmux mouse mode and history limit settings configurable.
  * Enhanced terminal scrollback size configuration for improved scroll history support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->