### PR TITLE
Enable Option-drag selection in ttyd

### DIFF
--- a/web/ttyd.go
+++ b/web/ttyd.go
@@ -40,6 +40,7 @@ func ttydArgs(sessionName string, port int) []string {
 		"--base-path", "/terminal/" + sessionName,
 		"-t", fmt.Sprintf("scrollback=%d", ttydScrollbackLines),
 		"-t", "fontFamily=HackNerdFontMono, monospace",
+		"-t", "macOptionClickForcesSelection=true",
 		"tmux", "new-session", "-A", "-s", webSession, "-t", "=" + sessionName,
 	}
 }

--- a/web/ttyd_test.go
+++ b/web/ttyd_test.go
@@ -9,18 +9,22 @@ import (
 	"time"
 )
 
-func TestTtydArgsIncludeMobileScrollback(t *testing.T) {
+func TestTtydArgsIncludeClientOptions(t *testing.T) {
 	args := ttydArgs("demo/session", 7681)
-	want := fmt.Sprintf("scrollback=%d", ttydScrollbackLines)
-	found := false
-	for i := 0; i < len(args)-1; i++ {
-		if args[i] == "-t" && args[i+1] == want {
-			found = true
-			break
+	for _, want := range []string{
+		fmt.Sprintf("scrollback=%d", ttydScrollbackLines),
+		"macOptionClickForcesSelection=true",
+	} {
+		found := false
+		for i := 0; i < len(args)-1; i++ {
+			if args[i] == "-t" && args[i+1] == want {
+				found = true
+				break
+			}
 		}
-	}
-	if !found {
-		t.Fatalf("expected ttyd args to include %q, got %v", want, args)
+		if !found {
+			t.Fatalf("expected ttyd args to include %q, got %v", want, args)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- pass xterm.js macOptionClickForcesSelection through ttyd client options
- cover ttyd client options in tests

## Verification
- go vet ./...
- go test -v -race ./...
- cd web/app && npm run build

Note: golangci-lint is not installed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled macOS users to configure Option-click behavior for text selection in the terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->