### PR TITLE
Run devx web UI as a containerized devx service

### DIFF
--- a/.devx/config.yaml
+++ b/.devx/config.yaml
@@ -5,3 +5,15 @@ disable_caddy: false
 editor: cursor
 tmuxp_template: /Users/jfox/.config/devx/session.yaml.tmpl
 web_port: 7777
+
+# Dogfood the devx web UI as a single devx service. WEB is the Go backend, which
+# serves the embedded SPA (web/dist) and the API on one port. devx allocates the
+# port, publishes it from the container (-p 127.0.0.1:WEB:WEB), and fronts it
+# with Caddy (*.localhost) and the CF tunnel, exactly like any other service.
+ports:
+  - WEB
+
+# Copy the gitignored dev token into the worktree so start_service.sh can read
+# it without committing a secret.
+bootstrap_files:
+  - .devx-web-token

--- a/.devx/session.yaml.tmpl
+++ b/.devx/session.yaml.tmpl
@@ -19,18 +19,29 @@ windows:
   - window_name: editor
     layout: tiled
     shell_command_before:
-      - cd {{.Path}}
+      - cd /workspace
       - export SESSION_NAME={{.Name}}
     panes:
       - 'pi -c'
 
+  # The web UI runs as a single containerized devx service. Panes run inside the
+  # container via docker exec (paths are container-internal: /workspace). The
+  # service port is exported from the devx-allocated Ports map.
+  - window_name: services
+    layout: tiled
+    shell_command_before:
+      - cd /workspace{{range $name, $port := .Ports}}
+      - export {{$name}}={{$port}}{{end}}
+      - export SESSION_NAME={{.Name}}
+    panes:
+      - /workspace/.devx/start_service.sh web
+
   - window_name: repo-root
     layout: tiled
     shell_command_before:
-      - cd {{.Path}}{{range $name, $port := .Ports}}
+      - cd /workspace{{range $name, $port := .Ports}}
       - export {{$name}}={{$port}}{{end}}{{if .Routes}}{{range $service, $hostname := .Routes}}
       - export {{toHostVar $service}}=http://{{$hostname}}{{end}}{{end}}
-      - export SESSION_NAME={{.Name}}    
+      - export SESSION_NAME={{.Name}}
     panes:
-      - cd {{.Path}}
-
+      - cd /workspace

--- a/.devx/start_service.sh
+++ b/.devx/start_service.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# .devx/start_service.sh - Run the devx web UI as a containerized devx service.
+#
+# This runs INSIDE the session container. The single "web" service builds the
+# Svelte SPA into web/dist (which the Go server embeds via //go:embed) and then
+# runs `devx web` bound to 0.0.0.0:$WEB so Docker port publishing + Caddy + the
+# CF tunnel can reach it like any normal service.
+#
+# To see UI changes: edit web/app, then restart this service (it rebuilds dist
+# and re-runs the Go server, which re-embeds the fresh dist). There is no vite
+# hot reload in this mode by design (option B: single built service).
+
+set -e
+
+SERVICE_NAME="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LOG_DIR="$PROJECT_DIR/.devx/logs"
+
+mkdir -p "$LOG_DIR"
+
+# Read the fixed dev token from the worktree. devx bootstraps it here from the
+# project root via bootstrap_files. Gitignored; never committed.
+read_token() {
+    local f="$PROJECT_DIR/.devx-web-token"
+    if [[ -f "$f" ]]; then
+        tr -d '[:space:]' < "$f"
+        return 0
+    fi
+    echo "ERROR: dev token not found at $f. Create .devx-web-token in the devx project root." >&2
+    return 1
+}
+
+start_service() {
+    case "$SERVICE_NAME" in
+        web)
+            if [[ -z "${WEB:-}" ]]; then
+                echo "ERROR: WEB port not set by devx" >&2
+                exit 1
+            fi
+            local token
+            token="$(read_token)"
+
+            # Build the SPA so the Go server embeds the current frontend.
+            # Install deps when missing or when package-lock has changed since
+            # the last install (so a dep bump doesn't build against stale deps).
+            cd "$PROJECT_DIR/web/app"
+            if [[ ! -d node_modules ]] || [[ package-lock.json -nt node_modules ]]; then
+                echo "Installing web/app dependencies..."
+                npm ci
+            fi
+            echo "Building web UI (web/dist)..."
+            npm run build
+
+            # exec the Go server bound to 0.0.0.0 so the published port + Caddy
+            # can reach it. exec replaces this script as the pane's foreground
+            # process: signals and the real exit code propagate, and tmux/devx
+            # reflect the true service state. Logs are tee'd so they appear in
+            # the pane and in the log file. This is a foreground server, so it
+            # does NOT touch the global web.pid daemon used by the host devx web.
+            cd "$PROJECT_DIR"
+            echo "Starting devx web backend on 0.0.0.0:$WEB (logs: $LOG_DIR/$SERVICE_NAME.log)"
+            exec env \
+                DEVX_WEB_PORT="$WEB" \
+                DEVX_WEB_BIND="0.0.0.0" \
+                DEVX_WEB_SECRET_TOKEN="$token" \
+                go run . web > >(tee "$LOG_DIR/$SERVICE_NAME.log") 2>&1
+            ;;
+        *)
+            echo "Unknown service: $SERVICE_NAME" >&2
+            exit 1
+            ;;
+    esac
+}
+
+echo "Starting $SERVICE_NAME service..."
+start_service

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ devx
 .pi/
 /dist/
 .devx/
+# Fixed dev token used when running the devx web UI as a containerized service.
+.devx-web-token
 web/app/node_modules/
 web/dist/
 .DS_Store

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,7 @@ func initConfig() {
 	viper.SetDefault("cloudflare_tunnel_config", "~/.cloudflared/config.yaml")
 	viper.SetDefault("web_secret_token", "")
 	viper.SetDefault("web_port", 7777)
+	viper.SetDefault("web_bind", "127.0.0.1")
 	viper.SetDefault("web_autostart", false)
 	viper.SetDefault("artifact_trigger_key", "Ctrl+Space")
 

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -59,6 +59,7 @@ func webPIDPath() string {
 func runWeb(cmd *cobra.Command, args []string) error {
 	token := viper.GetString("web_secret_token")
 	port := viper.GetInt("web_port")
+	bind := viper.GetString("web_bind")
 
 	if webDaemonFlag {
 		// Validate token before daemonizing so errors are caught in foreground
@@ -68,7 +69,7 @@ func runWeb(cmd *cobra.Command, args []string) error {
 		return startWebDaemon(port)
 	}
 
-	srv, err := web.New(token, port)
+	srv, err := web.NewWithBind(token, port, bind)
 	if err != nil {
 		return err
 	}

--- a/cmd/web_windows.go
+++ b/cmd/web_windows.go
@@ -57,8 +57,9 @@ func runWeb(cmd *cobra.Command, args []string) error {
 
 	token := viper.GetString("web_secret_token")
 	port := viper.GetInt("web_port")
+	bind := viper.GetString("web_bind")
 
-	srv, err := web.New(token, port)
+	srv, err := web.NewWithBind(token, port, bind)
 	if err != nil {
 		return err
 	}

--- a/web/app/vite.config.js
+++ b/web/app/vite.config.js
@@ -8,9 +8,9 @@ const backendOrigin = process.env.DEVX_WEB_ORIGIN ?? 'http://localhost:7777'
 // supplied as a comma-separated DEVX_WEB_ALLOWED_HOSTS env var. The Go server
 // (option B, built dist) does not use this; it only matters when running the
 // vite dev server behind Caddy/CF for hot-reload development.
-const extraAllowedHosts = process.env.DEVX_WEB_ALLOWED_HOSTS?.split(',')
+const extraAllowedHosts = (process.env.DEVX_WEB_ALLOWED_HOSTS?.split(',') ?? [])
   .map((h) => h.trim())
-  .filter(Boolean) ?? []
+  .filter(Boolean)
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/web/app/vite.config.js
+++ b/web/app/vite.config.js
@@ -4,6 +4,14 @@ import tailwindcss from '@tailwindcss/vite'
 
 const backendOrigin = process.env.DEVX_WEB_ORIGIN ?? 'http://localhost:7777'
 
+// Extra hostnames (e.g. CF tunnel domains) allowed to reach the dev server,
+// supplied as a comma-separated DEVX_WEB_ALLOWED_HOSTS env var. The Go server
+// (option B, built dist) does not use this; it only matters when running the
+// vite dev server behind Caddy/CF for hot-reload development.
+const extraAllowedHosts = process.env.DEVX_WEB_ALLOWED_HOSTS?.split(',')
+  .map((h) => h.trim())
+  .filter(Boolean) ?? []
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [tailwindcss(), svelte()],
@@ -12,6 +20,8 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    host: '0.0.0.0',
+    allowedHosts: ['localhost', '127.0.0.1', '.localhost', ...extraAllowedHosts],
     proxy: {
       '/api': backendOrigin,
       // Proxy /terminal/* to the backend, with WebSocket support for ttyd.

--- a/web/server.go
+++ b/web/server.go
@@ -18,6 +18,7 @@ import (
 type Server struct {
 	token  string
 	port   int
+	bind   string
 	server *http.Server
 	ttyd   *ttydManager
 	hub    *sseHub
@@ -25,10 +26,21 @@ type Server struct {
 
 // New creates a new Server. token must be non-empty.
 func New(token string, port int) (*Server, error) {
+	return NewWithBind(token, port, "")
+}
+
+// NewWithBind creates a new Server bound to the given address. bind defaults to
+// loopback (127.0.0.1) when empty. Binding to 0.0.0.0 is only intended for
+// running devx web inside a container where Docker port publishing requires it;
+// it must not be used to expose plain HTTP directly on an untrusted network.
+func NewWithBind(token string, port int, bind string) (*Server, error) {
 	if token == "" {
 		return nil, fmt.Errorf("web_secret_token must be set in config to use devx web")
 	}
-	return &Server{token: token, port: port, ttyd: newTtydManager(), hub: newSSEHub()}, nil
+	if bind == "" {
+		bind = "127.0.0.1"
+	}
+	return &Server{token: token, port: port, bind: bind, ttyd: newTtydManager(), hub: newSSEHub()}, nil
 }
 
 // Start begins listening and serving.
@@ -36,10 +48,12 @@ func (s *Server) Start() error {
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)
 
-	// Bind to loopback only — devx web is a local developer tool and must not
-	// be reachable from the network over plain HTTP.
+	// Bind to loopback by default — devx web is a local developer tool and must
+	// not be reachable from the network over plain HTTP. NewWithBind allows
+	// 0.0.0.0 for in-container use where Docker port publishing (and Caddy/CF
+	// fronting) require it.
 	s.server = &http.Server{
-		Addr:    fmt.Sprintf("127.0.0.1:%d", s.port),
+		Addr:    fmt.Sprintf("%s:%d", s.bind, s.port),
 		Handler: authMiddleware(s.token, mux),
 	}
 
@@ -48,7 +62,7 @@ func (s *Server) Start() error {
 		return fmt.Errorf("failed to listen on port %d: %w", s.port, err)
 	}
 
-	fmt.Printf("devx web listening on http://localhost:%d\n", s.port)
+	fmt.Printf("devx web listening on http://%s:%d\n", s.bind, s.port)
 	return s.server.Serve(ln)
 }
 

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -50,3 +50,33 @@ func TestAuthMiddlewarePassesNonAPIRoutes(t *testing.T) {
 		t.Errorf("expected 200 for non-API route, got %d", w.Code)
 	}
 }
+
+func TestNewWithBindDefaultsToLoopback(t *testing.T) {
+	srv, err := NewWithBind("test-secret", 0, "")
+	if err != nil {
+		t.Fatalf("NewWithBind returned error: %v", err)
+	}
+	if srv.bind != "127.0.0.1" {
+		t.Fatalf("empty bind should default to loopback, got %q", srv.bind)
+	}
+}
+
+func TestNewWithBindHonorsExplicitAddress(t *testing.T) {
+	srv, err := NewWithBind("test-secret", 0, "0.0.0.0")
+	if err != nil {
+		t.Fatalf("NewWithBind returned error: %v", err)
+	}
+	if srv.bind != "0.0.0.0" {
+		t.Fatalf("explicit bind not honored, got %q", srv.bind)
+	}
+}
+
+func TestNewDefaultsToLoopbackBind(t *testing.T) {
+	srv, err := New("test-secret", 0)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	if srv.bind != "127.0.0.1" {
+		t.Fatalf("New should default to loopback bind, got %q", srv.bind)
+	}
+}


### PR DESCRIPTION
## Summary

Enables running the devx web UI itself as a normal containerized devx service — auto-allocated port, published from the container, fronted by Caddy and the Cloudflare tunnel like any other service.

## Changes

- **`web_bind` / `DEVX_WEB_BIND`** (default `127.0.0.1`): new `web.NewWithBind(token, port, bind)`; `New()` delegates and keeps loopback behavior. The server can bind `0.0.0.0` when running inside a session container, where Docker port publishing + Caddy/CF fronting require it. `Start()` uses the configured bind. Doc comment warns it must not be used to expose plain HTTP on an untrusted network; the auth middleware still wraps the handler regardless of bind.
- **`cmd/{root,web,web_windows}.go`**: read `web_bind` from viper (default added) and pass it to `NewWithBind`.
- **`.devx/` service wiring**:
  - `config.yaml`: `ports: [WEB]`, `bootstrap_files: [.devx-web-token]`.
  - `session.yaml.tmpl`: a `services` window whose pane runs `start_service.sh` inside the container (container-internal `/workspace` paths, since panes run via `docker exec`); exports the devx-allocated `Ports`.
  - `start_service.sh`: single `web` service. Builds the embedded SPA (`npm ci` when deps missing/stale, `npm run build`), then `exec`s `devx web` bound to `0.0.0.0:$WEB` so signals/exit propagate and tmux/devx reflect true service state. Reads a gitignored dev token bootstrapped into the worktree.
- **`vite.config.js`**: set `host` / `allowedHosts` so the dev server works behind Caddy/CF when running the frontend in dev mode.
- **`.gitignore`**: ignore `.devx-web-token` (never committed; bootstrapped per-worktree).

## Testing

- `gofmt -l` (changed files clean), `go vet ./...`, `go build ./...`, `go test -race ./...` all pass locally.
- Added `web/server_test.go` cases: `NewWithBind` default-loopback, explicit-address, and `New()` delegation.
- Validated end-to-end in a real `gatepost`-target session: WEB port auto-allocated and published (`-p 127.0.0.1:PORT:PORT`), service runs in-container bound `0.0.0.0`, reachable via Caddy (`*.localhost`) and the CF tunnel (`*.jon-fox.com`), and listed as a devx service in the main UI.

## Notes

- Scope is intentionally limited to service-enabling config + the `web_bind` enabler. No UI/cosmetic changes; `web/dist` is unchanged (rebuilt in-container at service start).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web UI service can now run as a standalone devx service with flexible configuration
  * Web server now supports configurable bind addresses, enabling container and external deployments
  * Dev server can accept external connections via environment-driven host configuration

* **Tests**
  * Added tests for web server bind address configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->