### PR TITLE
Resolve bootstrap_files from project config, not cwd-dependent viper

### DIFF
--- a/cmd/session_create.go
+++ b/cmd/session_create.go
@@ -215,7 +215,7 @@ func runSessionCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := session.CopyBootstrapFiles(projectPath, worktreePath); err != nil {
+	if err := session.CopyBootstrapFiles(projectPath, worktreePath, cfg.BootstrapFiles); err != nil {
 		return fmt.Errorf("failed to copy bootstrap files: %w", err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	CaddyAPI               string   `mapstructure:"caddy_api"`
 	TmuxpTemplate          string   `mapstructure:"tmuxp_template"`
 	Ports                  []string `mapstructure:"ports"`
+	BootstrapFiles         []string `mapstructure:"bootstrap_files"`
 	ExternalDomain         string   `mapstructure:"external_domain"`
 	CloudflareTunnelID     string   `mapstructure:"cloudflare_tunnel_id"`
 	CloudflareTunnelConfig string   `mapstructure:"cloudflare_tunnel_config"`

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -9,9 +9,15 @@ import (
 	"github.com/spf13/viper"
 )
 
-// CopyBootstrapFiles copies configured bootstrap files from project root to the worktree
-func CopyBootstrapFiles(projectRoot, worktreePath string) error {
-	bootstrapFiles := viper.GetStringSlice("bootstrap_files")
+// CopyBootstrapFiles copies the given bootstrap files from the project root to
+// the worktree. When bootstrapFiles is nil, it falls back to the global viper
+// "bootstrap_files" key for backward compatibility; callers should prefer
+// passing the project's own config so resolution does not depend on the current
+// working directory.
+func CopyBootstrapFiles(projectRoot, worktreePath string, bootstrapFiles []string) error {
+	if bootstrapFiles == nil {
+		bootstrapFiles = viper.GetStringSlice("bootstrap_files")
+	}
 	if len(bootstrapFiles) == 0 {
 		return nil // No bootstrap files configured
 	}

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -1,0 +1,53 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestCopyBootstrapFilesExplicitList(t *testing.T) {
+	projectRoot := t.TempDir()
+	worktree := t.TempDir()
+
+	tokenPath := filepath.Join(projectRoot, ".devx-web-token")
+	if err := os.WriteFile(tokenPath, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Explicit list must be honored regardless of global viper state.
+	viper.Reset()
+	if err := CopyBootstrapFiles(projectRoot, worktree, []string{".devx-web-token"}); err != nil {
+		t.Fatalf("CopyBootstrapFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(worktree, ".devx-web-token"))
+	if err != nil {
+		t.Fatalf("token not copied to worktree: %v", err)
+	}
+	if string(got) != "secret" {
+		t.Fatalf("token content mismatch: %q", got)
+	}
+}
+
+func TestCopyBootstrapFilesNilFallsBackToViper(t *testing.T) {
+	projectRoot := t.TempDir()
+	worktree := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(projectRoot, "seed.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	viper.Reset()
+	viper.Set("bootstrap_files", []string{"seed.txt"})
+	t.Cleanup(viper.Reset)
+
+	if err := CopyBootstrapFiles(projectRoot, worktree, nil); err != nil {
+		t.Fatalf("CopyBootstrapFiles: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktree, "seed.txt")); err != nil {
+		t.Fatalf("viper fallback did not copy file: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`CopyBootstrapFiles` read `bootstrap_files` from the **global viper** instance. That key is only populated with a project's `.devx/config.yaml` when `devx` runs from a cwd **inside** that project (`FindProjectConfigDir` walks up from `os.Getwd`). Creating a session from any other directory (e.g. `devx session create foo --project devx` run from `/tmp`) silently copied nothing.

Concretely this broke the containerized web service added in #41: the gitignored `.devx-web-token` never landed in the worktree, and `start_service.sh` failed with:

```
ERROR: dev token not found at /workspace/.devx-web-token.
```

## Fix

- Add `BootstrapFiles []string` to the `Config` struct so `GetProjectConfig` captures the project's `bootstrap_files`.
- Pass the resolved list into `CopyBootstrapFiles(projectRoot, worktreePath, bootstrapFiles)`. `nil` still falls back to the global viper key for backward compatibility.

Resolution is now keyed off the **project path** and independent of the current working directory.

## Tests

- `TestCopyBootstrapFilesExplicitList` — explicit list is honored regardless of global viper state.
- `TestCopyBootstrapFilesNilFallsBackToViper` — nil preserves the legacy viper-based behavior.

Verified end-to-end: `devx session create … --project devx` run from `/tmp` (cwd without `.devx`) now logs `Copied: .devx-web-token` and the token lands in the worktree.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test -race ./config/ ./session/ ./cmd/` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Projects can now define bootstrap files in their configuration, which takes precedence over global settings.

* **Tests**
  - Added unit tests for bootstrap file configuration and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->