### PR TITLE
Fix terminal WebSocket 403 behind Caddy / Cloudflare tunnel

### DIFF
--- a/web/proxy.go
+++ b/web/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -12,18 +13,49 @@ import (
 
 const wsWriteDeadline = 60 * time.Second
 
+// effectiveHosts returns the host values that count as "same origin" for this
+// request. It always includes r.Host, and additionally includes
+// X-Forwarded-Host when present. devx sits behind a trusted reverse proxy
+// (Caddy, and Cloudflare's tunnel) that rewrites the upstream Host header to
+// "localhost" so dev servers accept the request, while forwarding the original
+// external hostname in X-Forwarded-Host. Without honoring it, the browser's
+// Origin (the real external host) never matches r.Host ("localhost"), which
+// rejected terminal WebSocket upgrades reached via Caddy or the Cloudflare
+// tunnel.
+func effectiveHosts(r *http.Request) []string {
+	hosts := []string{r.Host}
+	if xfh := r.Header.Get("X-Forwarded-Host"); xfh != "" {
+		// X-Forwarded-Host may be a comma-separated list; the first value is the
+		// original client-facing host.
+		if first, _, found := strings.Cut(xfh, ","); found {
+			xfh = first
+		}
+		hosts = append(hosts, strings.TrimSpace(xfh))
+	}
+	return hosts
+}
+
 var upgrader = websocket.Upgrader{
 	// Only allow requests whose Origin matches the server's own host.
 	// This prevents cross-site WebSocket hijacking: a malicious page opened
 	// in the same browser cannot connect to ws://localhost:<port>/terminal/*
-	// because its Origin won't match r.Host.
+	// because its Origin won't match the request host.
+	//
+	// effectiveHosts honors X-Forwarded-Host so the check still passes when the
+	// request is reached via the trusted Caddy reverse proxy / Cloudflare tunnel,
+	// which rewrite the upstream Host header to "localhost".
 	CheckOrigin: func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
 		if origin == "" {
 			// No Origin header = same-origin browser request; allow it.
 			return true
 		}
-		return origin == "http://"+r.Host || origin == "https://"+r.Host
+		for _, h := range effectiveHosts(r) {
+			if origin == "http://"+h || origin == "https://"+h {
+				return true
+			}
+		}
+		return false
 	},
 	Subprotocols: []string{"tty"},
 }

--- a/web/proxy_test.go
+++ b/web/proxy_test.go
@@ -1,0 +1,71 @@
+package web
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEffectiveHostsIncludesForwardedHost(t *testing.T) {
+	req := httptest.NewRequest("GET", "/terminal/demo/ws", nil)
+	req.Host = "localhost"
+	req.Header.Set("X-Forwarded-Host", "devx-demo-web.example.com")
+
+	hosts := effectiveHosts(req)
+	if len(hosts) != 2 || hosts[0] != "localhost" || hosts[1] != "devx-demo-web.example.com" {
+		t.Fatalf("unexpected effectiveHosts: %#v", hosts)
+	}
+}
+
+func TestEffectiveHostsTakesFirstForwardedHostValue(t *testing.T) {
+	req := httptest.NewRequest("GET", "/terminal/demo/ws", nil)
+	req.Host = "localhost"
+	req.Header.Set("X-Forwarded-Host", " devx-demo-web.example.com , internal")
+
+	hosts := effectiveHosts(req)
+	if len(hosts) != 2 || hosts[1] != "devx-demo-web.example.com" {
+		t.Fatalf("expected first forwarded host trimmed, got %#v", hosts)
+	}
+}
+
+func TestEffectiveHostsNoForwardedHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/terminal/demo/ws", nil)
+	req.Host = "localhost:7777"
+
+	hosts := effectiveHosts(req)
+	if len(hosts) != 1 || hosts[0] != "localhost:7777" {
+		t.Fatalf("expected only r.Host, got %#v", hosts)
+	}
+}
+
+func TestUpgraderCheckOriginHonorsForwardedHost(t *testing.T) {
+	// Behind Caddy/CF the upstream Host is rewritten to localhost while the
+	// browser's Origin carries the real external host (forwarded as XFH).
+	req := httptest.NewRequest("GET", "/terminal/demo/ws", nil)
+	req.Host = "localhost"
+	req.Header.Set("X-Forwarded-Host", "devx-demo-web.example.com")
+	req.Header.Set("Origin", "https://devx-demo-web.example.com")
+
+	if !upgrader.CheckOrigin(req) {
+		t.Fatal("WebSocket CheckOrigin should accept forwarded-host Origin")
+	}
+}
+
+func TestUpgraderCheckOriginRejectsForeignOrigin(t *testing.T) {
+	req := httptest.NewRequest("GET", "/terminal/demo/ws", nil)
+	req.Host = "localhost"
+	req.Header.Set("X-Forwarded-Host", "devx-demo-web.example.com")
+	req.Header.Set("Origin", "https://evil.example.com")
+
+	if upgrader.CheckOrigin(req) {
+		t.Fatal("WebSocket CheckOrigin must reject a foreign Origin")
+	}
+}
+
+func TestUpgraderCheckOriginAllowsMissingOrigin(t *testing.T) {
+	req := httptest.NewRequest("GET", "/terminal/demo/ws", nil)
+	req.Host = "localhost"
+
+	if !upgrader.CheckOrigin(req) {
+		t.Fatal("WebSocket CheckOrigin should allow a missing Origin (same-origin)")
+	}
+}


### PR DESCRIPTION
## Problem

The terminal's ttyd WebSocket fails to connect (shows "Reconnect") when the devx web UI is accessed through **Caddy** or the **Cloudflare tunnel**, but works fine on direct `http://127.0.0.1:<port>/`.

Root cause: the WebSocket upgrader's `CheckOrigin` compares the browser `Origin` against `r.Host`. devx's reverse proxies rewrite the upstream `Host` header to `localhost` so dev servers (Vite, etc.) accept the request:
- Caddy route sets `Host: localhost`
- CF tunnel sets `HTTPHostHeader: localhost`

…while forwarding the real external hostname only in `X-Forwarded-Host`. So the browser `Origin` (e.g. `https://devx-foo-web.example.com`) never matches `r.Host` (`localhost`) → WS upgrade rejected with **403** → terminal shows "Reconnect".

## Fix

Add `effectiveHosts(r)` which accepts `r.Host` **plus** `X-Forwarded-Host` (set by the trusted front proxy), and use it in `upgrader.CheckOrigin`.

Cross-site protection is preserved: `X-Forwarded-Host` is set by our own Caddy/CF front, not the browser, and a foreign `Origin` is still rejected.

## Validation

Reproduced and verified the WebSocket upgrade end-to-end:

| Path | Before | After |
|---|---|---|
| Direct `127.0.0.1:<port>` | 101 | 101 |
| Via Caddy (`*.localhost`) | **403** | **101** |
| Via CF tunnel (HTTP/1.1) | fails | **101** |

- `go build ./web/...`, `go vet ./web/`, `gofmt -l` clean
- New tests: `effectiveHosts` parsing, forwarded-host Origin acceptance, foreign-origin rejection, missing-Origin (same-origin) allow

## Note

This branch fixes the WebSocket `CheckOrigin` path that exists on `main`. A richer in-progress UI branch also adds an HTTP `/terminal/` provenance guard; the same `effectiveHosts` fix is applied there too and will arrive when that work merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket origin validation now correctly supports reverse proxy deployments by honoring X-Forwarded-Host headers, including comma-separated values.

* **Tests**
  * Added comprehensive tests for WebSocket origin validation in proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->