### PR TITLE
Persist Gatepost agent home and sandbox hooks

### DIFF
--- a/cmd/session_rm.go
+++ b/cmd/session_rm.go
@@ -141,6 +141,9 @@ func removeSessionByName(name string, opts removeSessionOptions) error {
 		uploadsDir := filepath.Join(home, ".devx", "uploads", name)
 		_ = os.RemoveAll(uploadsDir)
 	}
+	if err := removeGatepostStateDir(sess); err != nil {
+		fmt.Printf("Warning: failed to remove Gatepost state dir: %v\n", err)
+	}
 
 	// Remove any persisted cleanup-review details for this session. A failure
 	// here should not block teardown, but surface it so stray artifacts are not
@@ -170,6 +173,44 @@ func removeSessionByName(name string, opts removeSessionOptions) error {
 		}
 	}
 	fmt.Printf("Removed session '%s'\n", name)
+	return nil
+}
+
+func removeGatepostStateDir(sess *session.Session) error {
+	dir := sess.Target.Gatepost.SessionDir
+	if dir == "" {
+		dir = sess.Target.Gatepost.AgentHomeDir
+		if dir != "" {
+			dir = filepath.Dir(dir)
+		}
+	}
+	if dir == "" {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	root := filepath.Join(home, ".local", "share", "devx", "gatepost")
+	cleanDir, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+	cleanRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(cleanRoot, cleanDir)
+	if err != nil {
+		return err
+	}
+	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return fmt.Errorf("refusing to remove Gatepost state outside %s: %s", cleanRoot, cleanDir)
+	}
+	if err := os.RemoveAll(cleanDir); err != nil {
+		return err
+	}
+	fmt.Printf("Removed Gatepost state directory\n")
 	return nil
 }
 

--- a/cmd/session_rm.go
+++ b/cmd/session_rm.go
@@ -142,7 +142,7 @@ func removeSessionByName(name string, opts removeSessionOptions) error {
 		_ = os.RemoveAll(uploadsDir)
 	}
 	if err := removeGatepostStateDir(sess); err != nil {
-		fmt.Printf("Warning: failed to remove Gatepost state dir: %v\n", err)
+		return fmt.Errorf("failed to remove Gatepost state dir; session metadata retained for cleanup retry: %w", err)
 	}
 
 	// Remove any persisted cleanup-review details for this session. A failure

--- a/cmd/session_rm.go
+++ b/cmd/session_rm.go
@@ -124,6 +124,9 @@ func removeSessionByName(name string, opts removeSessionOptions) error {
 		tgt, err := target.Resolve(sess.TargetType())
 		if err == nil {
 			if err := tgt.Stop(context.Background(), sess.Target); err != nil {
+				if sess.TargetType() == "gatepost" {
+					return fmt.Errorf("failed to stop gatepost target; session metadata retained for cleanup retry: %w", err)
+				}
 				fmt.Printf("Warning: failed to stop %s target: %v\n", sess.TargetType(), err)
 			} else {
 				fmt.Printf("Stopped target runtime '%s'\n", target.RuntimeName(sess.Target))
@@ -192,25 +195,87 @@ func removeGatepostStateDir(sess *session.Session) error {
 		return err
 	}
 	root := filepath.Join(home, ".local", "share", "devx", "gatepost")
-	cleanDir, err := filepath.Abs(dir)
-	if err != nil {
-		return err
-	}
 	cleanRoot, err := filepath.Abs(root)
 	if err != nil {
 		return err
 	}
-	rel, err := filepath.Rel(cleanRoot, cleanDir)
+	cleanDir, err := filepath.Abs(dir)
 	if err != nil {
 		return err
 	}
-	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+	lexicalRel, err := filepath.Rel(cleanRoot, cleanDir)
+	if err != nil {
+		return err
+	}
+	if lexicalRel == "." || strings.HasPrefix(lexicalRel, ".."+string(filepath.Separator)) || lexicalRel == ".." || filepath.IsAbs(lexicalRel) {
 		return fmt.Errorf("refusing to remove Gatepost state outside %s: %s", cleanRoot, cleanDir)
 	}
-	if err := os.RemoveAll(cleanDir); err != nil {
+	if err := rejectSymlinksInPath(home, cleanRoot); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(cleanRoot); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to remove Gatepost state through symlinked root: %s", cleanRoot)
+	} else if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(cleanRoot)
+	if err != nil {
+		return err
+	}
+	if info, err := os.Lstat(cleanDir); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to remove symlinked Gatepost state directory: %s", cleanDir)
+	} else if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	resolvedDir, err := filepath.EvalSymlinks(cleanDir)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedDir)
+	if err != nil {
+		return err
+	}
+	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+		return fmt.Errorf("refusing to remove Gatepost state outside %s: %s", resolvedRoot, resolvedDir)
+	}
+	if err := os.RemoveAll(resolvedDir); err != nil {
 		return err
 	}
 	fmt.Printf("Removed Gatepost state directory\n")
+	return nil
+}
+
+func rejectSymlinksInPath(base, target string) error {
+	cleanBase, err := filepath.Abs(base)
+	if err != nil {
+		return err
+	}
+	cleanTarget, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(cleanBase, cleanTarget)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+		return nil
+	}
+	cur := cleanBase
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to remove Gatepost state through symlinked path component: %s", cur)
+		}
+	}
 	return nil
 }
 

--- a/cmd/session_rm_test.go
+++ b/cmd/session_rm_test.go
@@ -35,6 +35,28 @@ func TestRemoveGatepostStateDirRejectsOutsideRoot(t *testing.T) {
 	}
 }
 
+func TestRemoveGatepostStateDirRejectsSymlinkStateDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := filepath.Join(home, ".local", "share", "devx", "gatepost")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	link := filepath.Join(root, "demo")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	sess := &session.Session{Name: "demo"}
+	sess.Target.Gatepost.SessionDir = link
+	if err := removeGatepostStateDir(sess); err == nil {
+		t.Fatalf("expected symlinked Gatepost state dir to be rejected")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside target should remain: %v", err)
+	}
+}
+
 func TestValidateManualWorktreeRemovalAllowsManagedWorktree(t *testing.T) {
 	project := t.TempDir()
 	path := filepath.Join(project, ".worktrees", "safe")

--- a/cmd/session_rm_test.go
+++ b/cmd/session_rm_test.go
@@ -8,6 +8,33 @@ import (
 	"github.com/jfox85/devx/session"
 )
 
+func TestRemoveGatepostStateDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stateDir := filepath.Join(home, ".local", "share", "devx", "gatepost", "demo")
+	if err := os.MkdirAll(filepath.Join(stateDir, "agent-home", ".codex"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sess := &session.Session{Name: "demo"}
+	sess.Target.Gatepost.SessionDir = stateDir
+	if err := removeGatepostStateDir(sess); err != nil {
+		t.Fatalf("removeGatepostStateDir: %v", err)
+	}
+	if _, err := os.Stat(stateDir); !os.IsNotExist(err) {
+		t.Fatalf("state dir still exists or stat failed unexpectedly: %v", err)
+	}
+}
+
+func TestRemoveGatepostStateDirRejectsOutsideRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sess := &session.Session{Name: "demo"}
+	sess.Target.Gatepost.SessionDir = t.TempDir()
+	if err := removeGatepostStateDir(sess); err == nil {
+		t.Fatalf("expected outside Gatepost state dir to be rejected")
+	}
+}
+
 func TestValidateManualWorktreeRemovalAllowsManagedWorktree(t *testing.T) {
 	project := t.TempDir()
 	path := filepath.Join(project, ".worktrees", "safe")

--- a/session/metadata.go
+++ b/session/metadata.go
@@ -63,6 +63,7 @@ type GatepostMeta struct {
 	SessionDir          string   `json:"session_dir,omitempty"`
 	AuditDir            string   `json:"audit_dir,omitempty"`
 	ConfigDir           string   `json:"config_dir,omitempty"`
+	AgentHomeDir        string   `json:"agent_home_dir,omitempty"`
 	AuditLog            string   `json:"audit_log,omitempty"`
 	CompanionLog        string   `json:"companion_log,omitempty"`
 	ControlURL          string   `json:"control_url,omitempty"`

--- a/target/gatepost.go
+++ b/target/gatepost.go
@@ -116,13 +116,20 @@ func recreateGatepostDockerShell(ctx context.Context, r gatepostRuntime) error {
 	}()
 	go func() { netCh <- netErr{dockerRun(ctx, "network", "create", r.egressNet), r.egressNet} }()
 	go func() { netCh <- netErr{dockerRun(ctx, "network", "create", r.portsNet), r.portsNet} }()
+	var firstErr netErr
 	for i := 0; i < 3; i++ {
-		if result := <-netCh; result.err != nil {
-			_ = dockerRunIgnore(ctx, "network", "rm", r.internalNet)
-			_ = dockerRunIgnore(ctx, "network", "rm", r.egressNet)
-			_ = dockerRunIgnore(ctx, "network", "rm", r.portsNet)
-			return fmt.Errorf("create gatepost network %s: %w", result.name, result.err)
+		result := <-netCh
+		if result.err != nil && firstErr.err == nil {
+			firstErr = result
 		}
+	}
+	if firstErr.err != nil {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_ = dockerRunIgnore(cleanupCtx, "network", "rm", r.internalNet)
+		_ = dockerRunIgnore(cleanupCtx, "network", "rm", r.egressNet)
+		_ = dockerRunIgnore(cleanupCtx, "network", "rm", r.portsNet)
+		return fmt.Errorf("create gatepost network %s: %w", firstErr.name, firstErr.err)
 	}
 	return nil
 }
@@ -217,12 +224,21 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 	}
 	proxyArgs = append(proxyArgs, "--label", "devx.role=gatepost-proxy", proxyImage)
 	fmt.Println("Starting Gatepost proxy...")
+	cleanupRuntime := func(meta session.TargetMeta) error {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		return g.cleanupStrict(cleanupCtx, meta)
+	}
 	if err := dockerRun(ctx, proxyArgs...); err != nil {
-		_ = g.cleanup(ctx, session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet}})
+		if cleanupErr := cleanupRuntime(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+			return nil, fmt.Errorf("create gatepost proxy: %w; cleanup failed: %v", err, cleanupErr)
+		}
 		return nil, fmt.Errorf("create gatepost proxy: %w", err)
 	}
 	if err := dockerRun(ctx, "network", "connect", "--alias", "proxy", "--alias", "gatepost-events", runtime.internalNet, runtime.proxyName); err != nil {
-		_ = g.cleanup(ctx, session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet}})
+		if cleanupErr := cleanupRuntime(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+			return nil, fmt.Errorf("connect proxy to internal network: %w; cleanup failed: %v", err, cleanupErr)
+		}
 		return nil, fmt.Errorf("connect proxy to internal network: %w", err)
 	}
 	controlURL := fmt.Sprintf("http://127.0.0.1:%d", controlPort)
@@ -237,21 +253,25 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 		proc, err := startGatepostLogs(logsCtx, gatepostCfg, gatepostRoot, filepath.Join(runtime.auditDir, "audit.jsonl"), logsPort)
 		logsCh <- logsResult{proc, err}
 	}()
-	cleanupWithLogs := func(meta session.TargetMeta) {
+	cleanupWithLogs := func(meta session.TargetMeta) error {
 		logsCancel()
 		if r, ok := <-logsCh; ok && r.proc.PID > 0 {
-			stopGatepostLogs(r.proc.PID)
+			meta.Gatepost.LogsPID = r.proc.PID
 		}
-		_ = g.cleanup(ctx, meta)
+		return cleanupRuntime(meta)
 	}
 	if err := waitHTTP(ctx, controlURL+"/healthz", 30*time.Second); err != nil {
-		cleanupWithLogs(session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet}})
+		if cleanupErr := cleanupWithLogs(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+			return nil, fmt.Errorf("gatepost control did not become healthy: %w; cleanup failed: %v", err, cleanupErr)
+		}
 		return nil, fmt.Errorf("gatepost control did not become healthy: %w", err)
 	}
 	fmt.Println("Registering provider secrets...")
 	providerBootstrap, err := bootstrapGatepostProviderSecrets(gatepostCfg, gatepostRoot, controlURL, controlToken)
 	if err != nil {
-		cleanupWithLogs(session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet}})
+		if cleanupErr := cleanupWithLogs(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+			return nil, fmt.Errorf("%w; cleanup failed: %v", err, cleanupErr)
+		}
 		return nil, err
 	}
 
@@ -271,6 +291,9 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 	if mainGitDir != "" {
 		containerGitFile = filepath.Join(runtime.sessionDir, "container-dot-git")
 		if err := os.WriteFile(containerGitFile, []byte("gitdir: /root/.git-worktree\n"), 0o644); err != nil {
+			if cleanupErr := cleanupWithLogs(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+				return nil, fmt.Errorf("write container .git file: %w; cleanup failed: %v", err, cleanupErr)
+			}
 			return nil, fmt.Errorf("write container .git file: %w", err)
 		}
 	}
@@ -388,12 +411,16 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 	agentArgs = append(agentArgs, "--label", "devx.role=agent", agentImage, "sleep", "infinity")
 	fmt.Println("Starting agent container...")
 	if err := dockerRun(ctx, agentArgs...); err != nil {
-		cleanupWithLogs(session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet}})
+		if cleanupErr := cleanupWithLogs(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+			return nil, fmt.Errorf("create gatepost agent: %w; cleanup failed: %v", err, cleanupErr)
+		}
 		return nil, fmt.Errorf("create gatepost agent: %w", err)
 	}
 	// Connect agent to the internal network so it can reach the proxy/events service.
 	if err := dockerRun(ctx, "network", "connect", runtime.internalNet, runtime.agentName); err != nil {
-		cleanupWithLogs(session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet, PortsNetworkName: runtime.portsNet}})
+		if cleanupErr := cleanupWithLogs(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+			return nil, fmt.Errorf("connect agent to internal network: %w; cleanup failed: %v", err, cleanupErr)
+		}
 		return nil, fmt.Errorf("connect agent to internal network: %w", err)
 	}
 	if cfg := piConfigDir(); cfg != "" {
@@ -415,7 +442,9 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 				"true",
 			}, "\n")
 			if err := dockerRun(ctx, "exec", runtime.agentName, "bash", "-lc", bootstrapScript); err != nil {
-				cleanupWithLogs(session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet}})
+				if cleanupErr := cleanupWithLogs(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+					return nil, fmt.Errorf("bootstrap pi extensions: %w; cleanup failed: %v", err, cleanupErr)
+				}
 				return nil, fmt.Errorf("bootstrap pi extensions: %w", err)
 			}
 		}
@@ -455,19 +484,26 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 
 	containerID, err := dockerOutput(ctx, "inspect", "--format", "{{.Id}}", runtime.agentName)
 	if err != nil {
+		if cleanupErr := cleanupWithLogs(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+			return nil, fmt.Errorf("%w; cleanup failed: %v", err, cleanupErr)
+		}
 		return nil, err
 	}
 	// Collect the logs process that was started in parallel earlier.
 	logsCancel() // no longer need cancellation — we're collecting the result
 	logsRes := <-logsCh
 	if logsRes.err != nil {
-		_ = g.cleanup(ctx, session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet}})
+		if cleanupErr := cleanupRuntime(gatepostCleanupMeta(runtime, 0)); cleanupErr != nil {
+			return nil, fmt.Errorf("%w; cleanup failed: %v", logsRes.err, cleanupErr)
+		}
 		return nil, logsRes.err
 	}
 	logs := logsRes.proc
 	logsTokenPath := filepath.Join(runtime.sessionDir, "logs.token")
 	if err := os.WriteFile(logsTokenPath, []byte(logs.Token), 0o600); err != nil {
-		_ = g.cleanup(ctx, session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet, LogsPID: logs.PID}})
+		if cleanupErr := cleanupRuntime(gatepostCleanupMeta(runtime, logs.PID)); cleanupErr != nil {
+			return nil, fmt.Errorf("%w; cleanup failed: %v", err, cleanupErr)
+		}
 		return nil, err
 	}
 	success = true
@@ -476,26 +512,63 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 
 func (g *GatepostTarget) Stop(ctx context.Context, meta session.TargetMeta) error {
 	stopGatepostLogs(meta.Gatepost.LogsPID)
-	return g.cleanup(ctx, meta)
+	return g.cleanupStrict(ctx, meta)
 }
 
 func (g *GatepostTarget) cleanup(ctx context.Context, meta session.TargetMeta) error {
+	_ = g.cleanupWithRunner(ctx, meta, func(args ...string) error { return dockerRunIgnore(ctx, args...) })
+	return nil
+}
+
+func (g *GatepostTarget) cleanupStrict(ctx context.Context, meta session.TargetMeta) error {
+	return g.cleanupWithRunner(ctx, meta, func(args ...string) error { return dockerRun(ctx, args...) })
+}
+
+func (g *GatepostTarget) cleanupWithRunner(ctx context.Context, meta session.TargetMeta, run func(args ...string) error) error {
+	stopGatepostLogs(meta.Gatepost.LogsPID)
+	var errs []string
+	cleanup := func(args ...string) {
+		if err := run(args...); err != nil && !isDockerAlreadyGone(err) {
+			errs = append(errs, fmt.Sprintf("docker %s: %v", strings.Join(args, " "), err))
+		}
+	}
 	if meta.ContainerName != "" {
-		_ = dockerRunIgnore(ctx, "rm", "-f", meta.ContainerName)
+		cleanup("rm", "-f", meta.ContainerName)
 	}
 	if meta.Gatepost.ProxyContainerName != "" {
-		_ = dockerRunIgnore(ctx, "rm", "-f", meta.Gatepost.ProxyContainerName)
+		cleanup("rm", "-f", meta.Gatepost.ProxyContainerName)
 	}
 	if meta.NetworkName != "" {
-		_ = dockerRunIgnore(ctx, "network", "rm", meta.NetworkName)
+		cleanup("network", "rm", meta.NetworkName)
 	}
 	if meta.Gatepost.EgressNetworkName != "" {
-		_ = dockerRunIgnore(ctx, "network", "rm", meta.Gatepost.EgressNetworkName)
+		cleanup("network", "rm", meta.Gatepost.EgressNetworkName)
 	}
 	if meta.Gatepost.PortsNetworkName != "" {
-		_ = dockerRunIgnore(ctx, "network", "rm", meta.Gatepost.PortsNetworkName)
+		cleanup("network", "rm", meta.Gatepost.PortsNetworkName)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("gatepost runtime cleanup failed: %s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+func isDockerAlreadyGone(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no such") || strings.Contains(msg, "not found")
+}
+
+func gatepostCleanupMeta(r gatepostRuntime, logsPID int) session.TargetMeta {
+	return session.TargetMeta{
+		ContainerName: r.agentName,
+		NetworkName:   r.internalNet,
+		Gatepost: session.GatepostMeta{
+			ProxyContainerName: r.proxyName,
+			EgressNetworkName:  r.egressNet,
+			PortsNetworkName:   r.portsNet,
+			LogsPID:            logsPID,
+		},
+	}
 }
 
 // mainRepoGitDir returns the main repo's .git directory given a worktree path,
@@ -526,27 +599,48 @@ func gatepostAdaptersDir(gatepostRoot string) (string, error) {
 	if gatepostRoot == "" {
 		return "", nil
 	}
-	dir := filepath.Join(gatepostRoot, "adapters")
-	resolvedDir, err := filepath.EvalSymlinks(dir)
+	resolvedRoot, err := filepath.EvalSymlinks(gatepostRoot)
+	if err != nil {
+		return "", fmt.Errorf("trusted gatepost root unavailable %s: %w", gatepostRoot, err)
+	}
+	if err := validateTrustedGatepostPath(resolvedRoot, true); err != nil {
+		return "", err
+	}
+	resolvedDir, err := filepath.EvalSymlinks(filepath.Join(resolvedRoot, "adapters"))
 	if err != nil {
 		return "", fmt.Errorf("gatepost adapters unavailable under trusted root %s: %w", gatepostRoot, err)
 	}
-	if err := validateTrustedGatepostPath(resolvedDir, true); err != nil {
+	if err := validateTrustedGatepostChild(resolvedRoot, resolvedDir, true); err != nil {
 		return "", err
 	}
-	for _, rel := range []string{
-		filepath.Join("claude", "gatepost-events.py"),
-		filepath.Join("codex", "gatepost-events.py"),
-	} {
-		path, err := filepath.EvalSymlinks(filepath.Join(resolvedDir, rel))
+	for _, tool := range []string{"claude", "codex"} {
+		toolDir, err := filepath.EvalSymlinks(filepath.Join(resolvedDir, tool))
 		if err != nil {
-			return "", fmt.Errorf("gatepost adapter %s unavailable: %w", rel, err)
+			return "", fmt.Errorf("gatepost adapter dir %s unavailable: %w", tool, err)
 		}
-		if err := validateTrustedGatepostPath(path, false); err != nil {
+		if err := validateTrustedGatepostChild(resolvedRoot, toolDir, true); err != nil {
+			return "", err
+		}
+		path, err := filepath.EvalSymlinks(filepath.Join(toolDir, "gatepost-events.py"))
+		if err != nil {
+			return "", fmt.Errorf("gatepost adapter %s unavailable: %w", filepath.Join(tool, "gatepost-events.py"), err)
+		}
+		if err := validateTrustedGatepostChild(resolvedRoot, path, false); err != nil {
 			return "", err
 		}
 	}
 	return resolvedDir, nil
+}
+
+func validateTrustedGatepostChild(root, path string, wantDir bool) error {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("trusted Gatepost path escapes trusted root %s: %s", root, path)
+	}
+	return validateTrustedGatepostPath(path, wantDir)
 }
 
 func validateTrustedGatepostPath(path string, wantDir bool) error {

--- a/target/gatepost.go
+++ b/target/gatepost.go
@@ -25,35 +25,37 @@ import (
 type GatepostTarget struct{}
 
 type gatepostRuntime struct {
-	base        string
-	agentName   string
-	proxyName   string
-	internalNet string
-	egressNet   string
-	portsNet    string
-	sessionDir  string
-	auditDir    string
-	configDir   string
+	base         string
+	agentName    string
+	proxyName    string
+	internalNet  string
+	egressNet    string
+	portsNet     string
+	sessionDir   string
+	auditDir     string
+	configDir    string
+	agentHomeDir string
 }
 
 func (g *GatepostTarget) Type() string { return "gatepost" }
 
 func newGatepostRuntime(sessionName string) (gatepostRuntime, error) {
 	base := caddy.SanitizeHostname(sessionName)
-	sessionDir, auditDir, configDir, err := gatepostDirs(sessionName)
+	sessionDir, auditDir, configDir, agentHomeDir, err := gatepostDirs(sessionName)
 	if err != nil {
 		return gatepostRuntime{}, err
 	}
 	return gatepostRuntime{
-		base:        base,
-		agentName:   "devx-" + base,
-		proxyName:   "devx-" + base + "-gatepost-proxy",
-		internalNet: "devx-" + base + "-gatepost-internal",
-		egressNet:   "devx-" + base + "-gatepost-egress",
-		portsNet:    "devx-" + base + "-gatepost-ports",
-		sessionDir:  sessionDir,
-		auditDir:    auditDir,
-		configDir:   configDir,
+		base:         base,
+		agentName:    "devx-" + base,
+		proxyName:    "devx-" + base + "-gatepost-proxy",
+		internalNet:  "devx-" + base + "-gatepost-internal",
+		egressNet:    "devx-" + base + "-gatepost-egress",
+		portsNet:     "devx-" + base + "-gatepost-ports",
+		sessionDir:   sessionDir,
+		auditDir:     auditDir,
+		configDir:    configDir,
+		agentHomeDir: agentHomeDir,
 	}, nil
 }
 
@@ -63,6 +65,17 @@ func prepareGatepostStateDirs(r gatepostRuntime, policyPath string) error {
 	}
 	if err := os.MkdirAll(r.configDir, 0o700); err != nil {
 		return err
+	}
+	for _, dir := range []string{
+		r.agentHomeDir,
+		filepath.Join(r.agentHomeDir, ".pi", "agent", "sessions"),
+		filepath.Join(r.agentHomeDir, ".codex"),
+		filepath.Join(r.agentHomeDir, ".claude"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+		_ = os.Chmod(dir, 0o700)
 	}
 	if err := writeGatepostPolicy(policyPath); err != nil {
 		return err
@@ -123,9 +136,15 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 		return nil, err
 	}
 	gatepostCfg := opts.GatepostConfig
-	gatepostRoot := getenvDefault("DEVX_GATEPOST_ROOT", getenvDefault("GATEPOST_ROOT", gatepostCfg.Root))
+	// gatepost.root is a trusted config value. Do not use env root overrides for
+	// executable helper discovery; workspace shells can influence env.
+	gatepostRoot := gatepostCfg.Root
+	trustedAdaptersDir := gatepostAdaptersDir(gatepostRoot)
 	policyPath := filepath.Join(runtime.configDir, "policy.gatepost.yaml")
 	if err := prepareGatepostStateDirs(runtime, policyPath); err != nil {
+		return nil, err
+	}
+	if err := writeGatepostAgentHookConfigs(runtime, trustedAdaptersDir); err != nil {
 		return nil, err
 	}
 
@@ -248,6 +267,9 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 		"--network", runtime.portsNet,
 		"--restart", "unless-stopped",
 		"-v", opts.WorktreePath + ":/workspace",
+		"-v", filepath.Join(runtime.agentHomeDir, ".pi", "agent", "sessions") + ":/root/.pi/agent/sessions",
+		"-v", filepath.Join(runtime.agentHomeDir, ".codex") + ":/root/.codex",
+		"-v", filepath.Join(runtime.agentHomeDir, ".claude") + ":/root/.claude",
 		"-w", "/workspace",
 	}
 	if mainGitDir != "" {
@@ -261,6 +283,9 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 	}
 	if models := piModelsFile(); models != "" {
 		agentArgs = append(agentArgs, "-v", models+":/root/.pi/agent/models.json")
+	}
+	if trustedAdaptersDir != "" {
+		agentArgs = append(agentArgs, "-v", trustedAdaptersDir+":/opt/gatepost/adapters:ro")
 	}
 	// Bind-mount sessions.json read-only so `devx artifact` can resolve sessions inside the container.
 	sessionsPath := config.GetSessionsPath()
@@ -321,7 +346,8 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 		"NO_PROXY": "localhost,127.0.0.1,gatepost-events", "no_proxy": "localhost,127.0.0.1,gatepost-events",
 		"GATEPOST_EVENTS_URL": "http://gatepost-events:9100/v1/events", "GATEPOST_EVENTS_TOKEN": eventToken,
 		"GATEPOST_AGENT_ROLE": agentRole, "GATEPOST_AGENT_BRANCH": agentBranch,
-		"CLIPROXYAPI_API_KEY": "GATEPOST_SECRET:cliproxy-key", "OPENAI_API_KEY": "GATEPOST_SECRET:openai-key", "GEMINI_API_KEY": "GATEPOST_SECRET:gemini-key",
+		"CLIPROXYAPI_API_KEY": "GATEPOST_SECRET:cliproxy-key", "ANTHROPIC_API_KEY": "sk-ant-oat01-GATEPOST_SECRET:anthropic-oauth", "OPENAI_API_KEY": "GATEPOST_SECRET:openai-key", "GEMINI_API_KEY": "GATEPOST_SECRET:gemini-key",
+		"CODEX_HOME": "/root/.codex", "CODEX_DISABLE_UPDATE_CHECK": "1", "DISABLE_AUTOUPDATER": "1",
 		// DevX artifact support inside the container.
 		"SESSION_NAME": opts.SessionName, "DEVX_SESSION_PATH": "/workspace",
 		// Prevent Go from auto-downloading toolchains through the proxy (large zips can fail).
@@ -432,7 +458,7 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 		_ = g.cleanup(ctx, session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet, LogsPID: logs.PID}})
 		return nil, err
 	}
-	return &StartResult{Meta: session.TargetMeta{Type: "gatepost", ContainerID: containerID, ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Image: agentImage, Gatepost: session.GatepostMeta{Enabled: true, Runtime: "docker-mitmproxy", ProxyContainerName: runtime.proxyName, InternalNetworkName: runtime.internalNet, EgressNetworkName: runtime.egressNet, PortsNetworkName: runtime.portsNet, SessionDir: runtime.sessionDir, AuditDir: runtime.auditDir, ConfigDir: runtime.configDir, AuditLog: filepath.Join(runtime.auditDir, "audit.jsonl"), CompanionLog: filepath.Join(runtime.auditDir, "companion.jsonl"), ControlURL: controlURL, LogsURL: logs.PublicURL, LogsTokenPath: logsTokenPath, LogsPID: logs.PID, ProviderMode: providerBootstrap.Mode, ProviderCommand: providerBootstrap.Command, RegisteredProviders: providerBootstrap.Registered, ProviderWarnings: providerBootstrap.Warnings}}}, nil
+	return &StartResult{Meta: session.TargetMeta{Type: "gatepost", ContainerID: containerID, ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Image: agentImage, Gatepost: session.GatepostMeta{Enabled: true, Runtime: "docker-mitmproxy", ProxyContainerName: runtime.proxyName, InternalNetworkName: runtime.internalNet, EgressNetworkName: runtime.egressNet, PortsNetworkName: runtime.portsNet, SessionDir: runtime.sessionDir, AuditDir: runtime.auditDir, ConfigDir: runtime.configDir, AgentHomeDir: runtime.agentHomeDir, AuditLog: filepath.Join(runtime.auditDir, "audit.jsonl"), CompanionLog: filepath.Join(runtime.auditDir, "companion.jsonl"), ControlURL: controlURL, LogsURL: logs.PublicURL, LogsTokenPath: logsTokenPath, LogsPID: logs.PID, ProviderMode: providerBootstrap.Mode, ProviderCommand: providerBootstrap.Command, RegisteredProviders: providerBootstrap.Registered, ProviderWarnings: providerBootstrap.Warnings}}}, nil
 }
 
 func (g *GatepostTarget) Stop(ctx context.Context, meta session.TargetMeta) error {
@@ -483,13 +509,123 @@ func mainRepoGitDir(worktreePath string) string {
 	return mainGit
 }
 
-func gatepostDirs(sessionName string) (string, string, string, error) {
+func gatepostAdaptersDir(gatepostRoot string) string {
+	if gatepostRoot == "" {
+		return ""
+	}
+	dir := filepath.Join(gatepostRoot, "adapters")
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return ""
+	}
+	if info, err := os.Stat(resolvedDir); err != nil || !info.IsDir() || info.Mode().Perm()&0o002 != 0 {
+		return ""
+	}
+	for _, rel := range []string{
+		filepath.Join("claude", "gatepost-events.py"),
+		filepath.Join("codex", "gatepost-events.py"),
+	} {
+		path, err := filepath.EvalSymlinks(filepath.Join(resolvedDir, rel))
+		if err != nil {
+			return ""
+		}
+		if info, err := os.Stat(path); err != nil || info.IsDir() || info.Mode().Perm()&0o002 != 0 {
+			return ""
+		}
+	}
+	return resolvedDir
+}
+
+type gatepostHookEvent struct {
+	Name    string
+	Matcher string
+}
+
+func writeGatepostAgentHookConfigs(r gatepostRuntime, adaptersDir string) error {
+	if adaptersDir == "" {
+		return nil
+	}
+	if err := writeHookConfig(
+		filepath.Join(r.agentHomeDir, ".claude", "settings.json"),
+		"python3 /opt/gatepost/adapters/claude/gatepost-events.py",
+		[]gatepostHookEvent{
+			{"SessionStart", "startup|resume|clear|compact"}, {"UserPromptSubmit", ""},
+			{"PreToolUse", "*"}, {"PostToolUse", "*"}, {"PostToolUseFailure", "*"},
+			{"PermissionRequest", "*"}, {"PermissionDenied", "*"}, {"PostToolBatch", ""},
+			{"Stop", ""}, {"StopFailure", "*"}, {"SessionEnd", "*"},
+			{"PreCompact", "manual|auto"}, {"PostCompact", "manual|auto"},
+			{"SubagentStart", "*"}, {"SubagentStop", "*"}, {"Notification", "*"},
+			{"CwdChanged", ""}, {"InstructionsLoaded", "*"},
+		},
+	); err != nil {
+		return err
+	}
+	return writeHookConfig(
+		filepath.Join(r.agentHomeDir, ".codex", "hooks.json"),
+		"python3 /opt/gatepost/adapters/codex/gatepost-events.py",
+		[]gatepostHookEvent{
+			{"SessionStart", "startup|resume|clear|compact"}, {"UserPromptSubmit", ""},
+			{"PreToolUse", "*"}, {"PostToolUse", "*"}, {"PermissionRequest", "*"},
+			{"Stop", ""}, {"PreCompact", "manual|auto"}, {"PostCompact", "manual|auto"},
+			{"SubagentStart", "*"}, {"SubagentStop", "*"},
+		},
+	)
+}
+
+func writeHookConfig(path, command string, events []gatepostHookEvent) error {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to overwrite symlink hook config: %s", path)
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	type hookEntry struct {
+		Name          string `json:"name"`
+		Type          string `json:"type"`
+		Command       string `json:"command"`
+		Timeout       int    `json:"timeout"`
+		StatusMessage string `json:"statusMessage"`
+	}
+	type hookGroup struct {
+		Matcher string      `json:"matcher,omitempty"`
+		Hooks   []hookEntry `json:"hooks"`
+	}
+	data := struct {
+		Hooks map[string][]hookGroup `json:"hooks"`
+	}{Hooks: map[string][]hookGroup{}}
+	for _, event := range events {
+		group := hookGroup{
+			Matcher: event.Matcher,
+			Hooks: []hookEntry{{
+				Name:          "gatepost-events",
+				Type:          "command",
+				Command:       command,
+				Timeout:       10,
+				StatusMessage: "Gatepost event capture",
+			}},
+		}
+		data.Hooks[event.Name] = append(data.Hooks[event.Name], group)
+	}
+	body, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}
+
+func gatepostDirs(sessionName string) (string, string, string, string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 	base := filepath.Join(home, ".local", "share", "devx", "gatepost", caddy.SanitizeHostname(sessionName))
-	return base, filepath.Join(base, "audit"), filepath.Join(base, "config"), nil
+	return base, filepath.Join(base, "audit"), filepath.Join(base, "config"), filepath.Join(base, "agent-home"), nil
 }
 
 func freePort() (int, error) {
@@ -589,10 +725,9 @@ func ReprovisionGatepostSecrets(gp session.GatepostMeta, cfg GatepostRuntimeConf
 	if len(body.Secrets) > 0 {
 		return // secrets present, nothing to do
 	}
-	// Re-run provider bootstrap.
+	// Re-run provider bootstrap from the trusted configured Gatepost checkout.
 	log.Printf("gatepost reprovision: secrets empty for %s, re-bootstrapping", gp.ControlURL)
-	root := getenvDefault("DEVX_GATEPOST_ROOT", getenvDefault("GATEPOST_ROOT", cfg.Root))
-	if _, err := bootstrapGatepostProviderSecrets(cfg, root, gp.ControlURL, token); err != nil {
+	if _, err := bootstrapGatepostProviderSecrets(cfg, cfg.Root, gp.ControlURL, token); err != nil {
 		log.Printf("gatepost reprovision: %v", err)
 	} else {
 		log.Printf("gatepost reprovision: secrets restored")

--- a/target/gatepost.go
+++ b/target/gatepost.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/jfox85/devx/caddy"
@@ -515,11 +514,6 @@ func (g *GatepostTarget) Stop(ctx context.Context, meta session.TargetMeta) erro
 	return g.cleanupStrict(ctx, meta)
 }
 
-func (g *GatepostTarget) cleanup(ctx context.Context, meta session.TargetMeta) error {
-	_ = g.cleanupWithRunner(ctx, meta, func(args ...string) error { return dockerRunIgnore(ctx, args...) })
-	return nil
-}
-
 func (g *GatepostTarget) cleanupStrict(ctx context.Context, meta session.TargetMeta) error {
 	return g.cleanupWithRunner(ctx, meta, func(args ...string) error { return dockerRun(ctx, args...) })
 }
@@ -657,14 +651,7 @@ func validateTrustedGatepostPath(path string, wantDir bool) error {
 	if info.Mode().Perm()&0o022 != 0 {
 		return fmt.Errorf("trusted Gatepost path is group/world-writable: %s", path)
 	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return fmt.Errorf("could not inspect owner for trusted Gatepost path: %s", path)
-	}
-	if int(stat.Uid) != os.Getuid() {
-		return fmt.Errorf("trusted Gatepost path owner uid %d does not match current uid %d: %s", stat.Uid, os.Getuid(), path)
-	}
-	return nil
+	return validateTrustedGatepostOwner(path, info)
 }
 
 func removeGatepostRuntimeState(r gatepostRuntime) error {

--- a/target/gatepost.go
+++ b/target/gatepost.go
@@ -510,8 +510,15 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 }
 
 func (g *GatepostTarget) Stop(ctx context.Context, meta session.TargetMeta) error {
-	stopGatepostLogs(meta.Gatepost.LogsPID)
-	return g.cleanupStrict(ctx, meta)
+	logsErr := stopGatepostLogs(meta.Gatepost.LogsPID)
+	cleanupErr := g.cleanupStrict(ctx, meta)
+	if logsErr != nil && cleanupErr != nil {
+		return fmt.Errorf("stop gatepost logs: %w; cleanup failed: %v", logsErr, cleanupErr)
+	}
+	if logsErr != nil {
+		return logsErr
+	}
+	return cleanupErr
 }
 
 func (g *GatepostTarget) cleanupStrict(ctx context.Context, meta session.TargetMeta) error {
@@ -519,8 +526,10 @@ func (g *GatepostTarget) cleanupStrict(ctx context.Context, meta session.TargetM
 }
 
 func (g *GatepostTarget) cleanupWithRunner(ctx context.Context, meta session.TargetMeta, run func(args ...string) error) error {
-	stopGatepostLogs(meta.Gatepost.LogsPID)
 	var errs []string
+	if err := stopGatepostLogs(meta.Gatepost.LogsPID); err != nil {
+		errs = append(errs, fmt.Sprintf("stop gatepost logs: %v", err))
+	}
 	cleanup := func(args ...string) {
 		if err := run(args...); err != nil && !isDockerAlreadyGone(err) {
 			errs = append(errs, fmt.Sprintf("docker %s: %v", strings.Join(args, " "), err))

--- a/target/gatepost.go
+++ b/target/gatepost.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/jfox85/devx/caddy"
@@ -139,11 +140,22 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 	// gatepost.root is a trusted config value. Do not use env root overrides for
 	// executable helper discovery; workspace shells can influence env.
 	gatepostRoot := gatepostCfg.Root
-	trustedAdaptersDir := gatepostAdaptersDir(gatepostRoot)
+	trustedAdaptersDir, err := gatepostAdaptersDir(gatepostRoot)
+	if err != nil {
+		return nil, err
+	}
 	policyPath := filepath.Join(runtime.configDir, "policy.gatepost.yaml")
+	statePrepared := false
+	success := false
+	defer func() {
+		if statePrepared && !success {
+			_ = removeGatepostRuntimeState(runtime)
+		}
+	}()
 	if err := prepareGatepostStateDirs(runtime, policyPath); err != nil {
 		return nil, err
 	}
+	statePrepared = true
 	if err := writeGatepostAgentHookConfigs(runtime, trustedAdaptersDir); err != nil {
 		return nil, err
 	}
@@ -458,6 +470,7 @@ func (g *GatepostTarget) Start(ctx context.Context, opts StartOpts) (*StartResul
 		_ = g.cleanup(ctx, session.TargetMeta{ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Gatepost: session.GatepostMeta{ProxyContainerName: runtime.proxyName, EgressNetworkName: runtime.egressNet, LogsPID: logs.PID}})
 		return nil, err
 	}
+	success = true
 	return &StartResult{Meta: session.TargetMeta{Type: "gatepost", ContainerID: containerID, ContainerName: runtime.agentName, NetworkName: runtime.internalNet, Image: agentImage, Gatepost: session.GatepostMeta{Enabled: true, Runtime: "docker-mitmproxy", ProxyContainerName: runtime.proxyName, InternalNetworkName: runtime.internalNet, EgressNetworkName: runtime.egressNet, PortsNetworkName: runtime.portsNet, SessionDir: runtime.sessionDir, AuditDir: runtime.auditDir, ConfigDir: runtime.configDir, AgentHomeDir: runtime.agentHomeDir, AuditLog: filepath.Join(runtime.auditDir, "audit.jsonl"), CompanionLog: filepath.Join(runtime.auditDir, "companion.jsonl"), ControlURL: controlURL, LogsURL: logs.PublicURL, LogsTokenPath: logsTokenPath, LogsPID: logs.PID, ProviderMode: providerBootstrap.Mode, ProviderCommand: providerBootstrap.Command, RegisteredProviders: providerBootstrap.Registered, ProviderWarnings: providerBootstrap.Warnings}}}, nil
 }
 
@@ -509,17 +522,17 @@ func mainRepoGitDir(worktreePath string) string {
 	return mainGit
 }
 
-func gatepostAdaptersDir(gatepostRoot string) string {
+func gatepostAdaptersDir(gatepostRoot string) (string, error) {
 	if gatepostRoot == "" {
-		return ""
+		return "", nil
 	}
 	dir := filepath.Join(gatepostRoot, "adapters")
 	resolvedDir, err := filepath.EvalSymlinks(dir)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("gatepost adapters unavailable under trusted root %s: %w", gatepostRoot, err)
 	}
-	if info, err := os.Stat(resolvedDir); err != nil || !info.IsDir() || info.Mode().Perm()&0o002 != 0 {
-		return ""
+	if err := validateTrustedGatepostPath(resolvedDir, true); err != nil {
+		return "", err
 	}
 	for _, rel := range []string{
 		filepath.Join("claude", "gatepost-events.py"),
@@ -527,13 +540,44 @@ func gatepostAdaptersDir(gatepostRoot string) string {
 	} {
 		path, err := filepath.EvalSymlinks(filepath.Join(resolvedDir, rel))
 		if err != nil {
-			return ""
+			return "", fmt.Errorf("gatepost adapter %s unavailable: %w", rel, err)
 		}
-		if info, err := os.Stat(path); err != nil || info.IsDir() || info.Mode().Perm()&0o002 != 0 {
-			return ""
+		if err := validateTrustedGatepostPath(path, false); err != nil {
+			return "", err
 		}
 	}
-	return resolvedDir
+	return resolvedDir, nil
+}
+
+func validateTrustedGatepostPath(path string, wantDir bool) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if wantDir && !info.IsDir() {
+		return fmt.Errorf("trusted Gatepost path is not a directory: %s", path)
+	}
+	if !wantDir && info.IsDir() {
+		return fmt.Errorf("trusted Gatepost adapter is a directory: %s", path)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf("trusted Gatepost path is group/world-writable: %s", path)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("could not inspect owner for trusted Gatepost path: %s", path)
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("trusted Gatepost path owner uid %d does not match current uid %d: %s", stat.Uid, os.Getuid(), path)
+	}
+	return nil
+}
+
+func removeGatepostRuntimeState(r gatepostRuntime) error {
+	if r.sessionDir == "" {
+		return nil
+	}
+	return os.RemoveAll(r.sessionDir)
 }
 
 type gatepostHookEvent struct {

--- a/target/gatepost_agent_home_test.go
+++ b/target/gatepost_agent_home_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestGatepostAdaptersDirRequiresHookFiles(t *testing.T) {
 	root := t.TempDir()
-	if got := gatepostAdaptersDir(root); got != "" {
-		t.Fatalf("gatepostAdaptersDir without hook files = %q, want empty", got)
+	if got, err := gatepostAdaptersDir(root); err == nil || got != "" {
+		t.Fatalf("gatepostAdaptersDir without hook files = %q, %v; want empty with error", got, err)
 	}
 	for _, rel := range []string{
 		filepath.Join("adapters", "claude", "gatepost-events.py"),
@@ -28,8 +28,34 @@ func TestGatepostAdaptersDirRequiresHookFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := gatepostAdaptersDir(root); got != want {
+	got, err := gatepostAdaptersDir(root)
+	if err != nil {
+		t.Fatalf("gatepostAdaptersDir unexpected error: %v", err)
+	}
+	if got != want {
 		t.Fatalf("gatepostAdaptersDir = %q, want %q", got, want)
+	}
+}
+
+func TestGatepostAdaptersDirRejectsWritableTrustedPaths(t *testing.T) {
+	root := t.TempDir()
+	for _, rel := range []string{
+		filepath.Join("adapters", "claude", "gatepost-events.py"),
+		filepath.Join("adapters", "codex", "gatepost-events.py"),
+	} {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("#!/usr/bin/env python3\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(filepath.Join(root, "adapters", "claude", "gatepost-events.py"), 0o664); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := gatepostAdaptersDir(root); err == nil || got != "" {
+		t.Fatalf("gatepostAdaptersDir with group-writable adapter = %q, %v; want empty with error", got, err)
 	}
 }
 
@@ -73,6 +99,20 @@ func TestWriteHookConfigRefusesSymlink(t *testing.T) {
 	}
 	if err := writeHookConfig(link, "python3 /opt/gatepost/adapters/claude/gatepost-events.py", nil); err == nil {
 		t.Fatalf("writeHookConfig followed symlink; want refusal")
+	}
+}
+
+func TestRemoveGatepostRuntimeStateRemovesSessionDir(t *testing.T) {
+	dir := t.TempDir()
+	r := gatepostRuntime{sessionDir: filepath.Join(dir, "session")}
+	if err := os.MkdirAll(filepath.Join(r.sessionDir, "agent-home"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeGatepostRuntimeState(r); err != nil {
+		t.Fatalf("removeGatepostRuntimeState: %v", err)
+	}
+	if _, err := os.Stat(r.sessionDir); !os.IsNotExist(err) {
+		t.Fatalf("session dir still exists or unexpected stat error: %v", err)
 	}
 }
 

--- a/target/gatepost_agent_home_test.go
+++ b/target/gatepost_agent_home_test.go
@@ -1,10 +1,13 @@
 package target
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jfox85/devx/session"
 )
 
 func TestGatepostAdaptersDirRequiresHookFiles(t *testing.T) {
@@ -56,6 +59,70 @@ func TestGatepostAdaptersDirRejectsWritableTrustedPaths(t *testing.T) {
 	}
 	if got, err := gatepostAdaptersDir(root); err == nil || got != "" {
 		t.Fatalf("gatepostAdaptersDir with group-writable adapter = %q, %v; want empty with error", got, err)
+	}
+}
+
+func TestGatepostAdaptersDirRejectsWritableIntermediateDir(t *testing.T) {
+	root := t.TempDir()
+	for _, rel := range []string{
+		filepath.Join("adapters", "claude", "gatepost-events.py"),
+		filepath.Join("adapters", "codex", "gatepost-events.py"),
+	} {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("#!/usr/bin/env python3\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chmod(filepath.Join(root, "adapters", "claude"), 0o775); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := gatepostAdaptersDir(root); err == nil || got != "" {
+		t.Fatalf("gatepostAdaptersDir with group-writable tool dir = %q, %v; want empty with error", got, err)
+	}
+}
+
+func TestGatepostAdaptersDirRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	escape := t.TempDir()
+	for _, base := range []string{root, escape} {
+		for _, rel := range []string{
+			filepath.Join("adapters", "claude", "gatepost-events.py"),
+			filepath.Join("adapters", "codex", "gatepost-events.py"),
+		} {
+			path := filepath.Join(base, rel)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("#!/usr/bin/env python3\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := os.RemoveAll(filepath.Join(root, "adapters", "claude")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(escape, "adapters", "claude"), filepath.Join(root, "adapters", "claude")); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := gatepostAdaptersDir(root); err == nil || got != "" {
+		t.Fatalf("gatepostAdaptersDir with symlink escape = %q, %v; want empty with error", got, err)
+	}
+}
+
+func TestGatepostCleanupStrictReportsFailures(t *testing.T) {
+	g := &GatepostTarget{}
+	meta := session.TargetMeta{ContainerName: "agent", NetworkName: "internal", Gatepost: session.GatepostMeta{ProxyContainerName: "proxy"}}
+	err := g.cleanupWithRunner(context.Background(), meta, func(args ...string) error {
+		if len(args) > 0 && args[0] == "rm" {
+			return nil
+		}
+		return os.ErrPermission
+	})
+	if err == nil {
+		t.Fatal("cleanupWithRunner returned nil; want propagated cleanup error")
 	}
 }
 

--- a/target/gatepost_agent_home_test.go
+++ b/target/gatepost_agent_home_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -85,6 +86,9 @@ func TestGatepostAdaptersDirRejectsWritableIntermediateDir(t *testing.T) {
 }
 
 func TestGatepostAdaptersDirRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior/privileges vary on Windows runners")
+	}
 	root := t.TempDir()
 	escape := t.TempDir()
 	for _, base := range []string{root, escape} {
@@ -148,13 +152,16 @@ func TestWriteGatepostAgentHookConfigs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("stat %s: %v", path, err)
 		}
-		if got := info.Mode().Perm(); got != 0o600 {
+		if got := info.Mode().Perm(); runtime.GOOS != "windows" && got != 0o600 {
 			t.Fatalf("%s mode = %o, want 600", path, got)
 		}
 	}
 }
 
 func TestWriteHookConfigRefusesSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior/privileges vary on Windows runners")
+	}
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.json")
 	link := filepath.Join(dir, "settings.json")
@@ -186,6 +193,7 @@ func TestRemoveGatepostRuntimeStateRemovesSessionDir(t *testing.T) {
 func TestPrepareGatepostStateDirsCreatesAgentHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	r, err := newGatepostRuntime("demo/session")
 	if err != nil {

--- a/target/gatepost_agent_home_test.go
+++ b/target/gatepost_agent_home_test.go
@@ -1,0 +1,126 @@
+package target
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGatepostAdaptersDirRequiresHookFiles(t *testing.T) {
+	root := t.TempDir()
+	if got := gatepostAdaptersDir(root); got != "" {
+		t.Fatalf("gatepostAdaptersDir without hook files = %q, want empty", got)
+	}
+	for _, rel := range []string{
+		filepath.Join("adapters", "claude", "gatepost-events.py"),
+		filepath.Join("adapters", "codex", "gatepost-events.py"),
+	} {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte("#!/usr/bin/env python3\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	want, err := filepath.EvalSymlinks(filepath.Join(root, "adapters"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gatepostAdaptersDir(root); got != want {
+		t.Fatalf("gatepostAdaptersDir = %q, want %q", got, want)
+	}
+}
+
+func TestWriteGatepostAgentHookConfigs(t *testing.T) {
+	r := gatepostRuntime{agentHomeDir: t.TempDir()}
+	adapters := t.TempDir()
+	if err := writeGatepostAgentHookConfigs(r, adapters); err != nil {
+		t.Fatalf("writeGatepostAgentHookConfigs: %v", err)
+	}
+	for _, rel := range []string{
+		filepath.Join(".claude", "settings.json"),
+		filepath.Join(".codex", "hooks.json"),
+	} {
+		path := filepath.Join(r.agentHomeDir, rel)
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(body), "gatepost-events") {
+			t.Fatalf("%s does not contain gatepost-events: %s", path, body)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("%s mode = %o, want 600", path, got)
+		}
+	}
+}
+
+func TestWriteHookConfigRefusesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.json")
+	link := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(target, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeHookConfig(link, "python3 /opt/gatepost/adapters/claude/gatepost-events.py", nil); err == nil {
+		t.Fatalf("writeHookConfig followed symlink; want refusal")
+	}
+}
+
+func TestPrepareGatepostStateDirsCreatesAgentHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	r, err := newGatepostRuntime("demo/session")
+	if err != nil {
+		t.Fatalf("newGatepostRuntime: %v", err)
+	}
+	policyPath := filepath.Join(r.configDir, "policy.gatepost.yaml")
+	if err := prepareGatepostStateDirs(r, policyPath); err != nil {
+		t.Fatalf("prepareGatepostStateDirs: %v", err)
+	}
+
+	wantBase := filepath.Join(home, ".local", "share", "devx", "gatepost", "demo-session")
+	if r.sessionDir != wantBase {
+		t.Fatalf("sessionDir = %q, want %q", r.sessionDir, wantBase)
+	}
+	for _, dir := range []string{
+		r.auditDir,
+		r.configDir,
+		r.agentHomeDir,
+		filepath.Join(r.agentHomeDir, ".pi", "agent", "sessions"),
+		filepath.Join(r.agentHomeDir, ".codex"),
+		filepath.Join(r.agentHomeDir, ".claude"),
+	} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("expected dir %s: %v", dir, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", dir)
+		}
+	}
+
+	for _, file := range []string{
+		filepath.Join(r.auditDir, "audit.jsonl"),
+		filepath.Join(r.auditDir, "companion.jsonl"),
+		policyPath,
+	} {
+		info, err := os.Stat(file)
+		if err != nil {
+			t.Fatalf("expected file %s: %v", file, err)
+		}
+		if info.IsDir() {
+			t.Fatalf("%s is a directory", file)
+		}
+	}
+}

--- a/target/gatepost_logs.go
+++ b/target/gatepost_logs.go
@@ -57,11 +57,15 @@ func startGatepostLogs(ctx context.Context, cfg GatepostRuntimeConfig, gatepostR
 	select {
 	case <-done:
 	case <-time.After(30 * time.Second):
-		stopGatepostLogsProcessGroup(cmd.Process.Pid)
+		if stopErr := stopGatepostLogsProcessGroup(cmd.Process.Pid); stopErr != nil {
+			return gatepostLogsProcess{}, fmt.Errorf("timed out waiting for gatepost-logs URL; stop failed: %w", stopErr)
+		}
 		return gatepostLogsProcess{}, fmt.Errorf("timed out waiting for gatepost-logs URL")
 	}
 	if result.Token == "" {
-		stopGatepostLogsProcessGroup(cmd.Process.Pid)
+		if stopErr := stopGatepostLogsProcessGroup(cmd.Process.Pid); stopErr != nil {
+			return gatepostLogsProcess{}, fmt.Errorf("gatepost-logs did not report an access token; stop failed: %w", stopErr)
+		}
 		return gatepostLogsProcess{}, fmt.Errorf("gatepost-logs did not report an access token")
 	}
 	return result, nil
@@ -84,9 +88,9 @@ func gatepostLogsCommand(cfg GatepostRuntimeConfig, gatepostRoot, auditLog strin
 	return "", nil, "", fmt.Errorf("gatepost logs command not found; set trusted gatepost.logs_command, or set trusted gatepost.root to a Gatepost checkout")
 }
 
-func stopGatepostLogs(pid int) {
+func stopGatepostLogs(pid int) error {
 	if pid <= 0 {
-		return
+		return nil
 	}
-	stopGatepostLogsProcessGroup(pid)
+	return stopGatepostLogsProcessGroup(pid)
 }

--- a/target/gatepost_logs.go
+++ b/target/gatepost_logs.go
@@ -57,11 +57,11 @@ func startGatepostLogs(ctx context.Context, cfg GatepostRuntimeConfig, gatepostR
 	select {
 	case <-done:
 	case <-time.After(30 * time.Second):
-		_ = cmd.Process.Kill()
+		stopGatepostLogsProcessGroup(cmd.Process.Pid)
 		return gatepostLogsProcess{}, fmt.Errorf("timed out waiting for gatepost-logs URL")
 	}
 	if result.Token == "" {
-		_ = cmd.Process.Kill()
+		stopGatepostLogsProcessGroup(cmd.Process.Pid)
 		return gatepostLogsProcess{}, fmt.Errorf("gatepost-logs did not report an access token")
 	}
 	return result, nil
@@ -88,8 +88,5 @@ func stopGatepostLogs(pid int) {
 	if pid <= 0 {
 		return
 	}
-	p, err := os.FindProcess(pid)
-	if err == nil {
-		_ = p.Kill()
-	}
+	stopGatepostLogsProcessGroup(pid)
 }

--- a/target/gatepost_logs.go
+++ b/target/gatepost_logs.go
@@ -69,10 +69,10 @@ func startGatepostLogs(ctx context.Context, cfg GatepostRuntimeConfig, gatepostR
 
 func gatepostLogsCommand(cfg GatepostRuntimeConfig, gatepostRoot, auditLog string, port int) (string, []string, string, error) {
 	listen := fmt.Sprintf("127.0.0.1:%d", port)
-	if raw := getenvDefault("DEVX_GATEPOST_LOGS_CMD", cfg.LogsCommand); raw != "" {
+	if raw := cfg.LogsCommand; raw != "" {
 		fields := strings.Fields(raw)
 		if len(fields) == 0 {
-			return "", nil, "", fmt.Errorf("DEVX_GATEPOST_LOGS_CMD is empty")
+			return "", nil, "", fmt.Errorf("gatepost.logs_command is empty")
 		}
 		return fields[0], append(fields[1:], "--audit", auditLog, "--listen", listen), "", nil
 	}
@@ -81,7 +81,7 @@ func gatepostLogsCommand(cfg GatepostRuntimeConfig, gatepostRoot, auditLog strin
 			return "go", []string{"run", "./cmd/gatepost-logs", "--audit", auditLog, "--listen", listen}, gatepostRoot, nil
 		}
 	}
-	return "", nil, "", fmt.Errorf("gatepost logs command not found; set trusted gatepost.logs_command/DEVX_GATEPOST_LOGS_CMD, or set gatepost.root/DEVX_GATEPOST_ROOT to a Gatepost checkout")
+	return "", nil, "", fmt.Errorf("gatepost logs command not found; set trusted gatepost.logs_command, or set trusted gatepost.root to a Gatepost checkout")
 }
 
 func stopGatepostLogs(pid int) {

--- a/target/gatepost_logs_test.go
+++ b/target/gatepost_logs_test.go
@@ -1,0 +1,27 @@
+package target
+
+import "testing"
+
+func TestGatepostLogsCommandIgnoresEnvOverride(t *testing.T) {
+	t.Setenv("DEVX_GATEPOST_LOGS_CMD", "/tmp/untrusted-logs")
+	cfg := GatepostRuntimeConfig{LogsCommand: "/trusted/gatepost-logs --verbose"}
+	cmd, args, dir, err := gatepostLogsCommand(cfg, "", "/tmp/audit.jsonl", 12345)
+	if err != nil {
+		t.Fatalf("gatepostLogsCommand: %v", err)
+	}
+	if cmd != "/trusted/gatepost-logs" {
+		t.Fatalf("cmd = %q, want trusted config command", cmd)
+	}
+	if dir != "" {
+		t.Fatalf("dir = %q, want empty for explicit command", dir)
+	}
+	want := []string{"--verbose", "--audit", "/tmp/audit.jsonl", "--listen", "127.0.0.1:12345"}
+	if len(args) != len(want) {
+		t.Fatalf("args len = %d, want %d: %#v", len(args), len(want), args)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q (all args %#v)", i, args[i], want[i], args)
+		}
+	}
+}

--- a/target/gatepost_logs_unix.go
+++ b/target/gatepost_logs_unix.go
@@ -3,10 +3,22 @@
 package target
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
 
 func detachGatepostLogsProcess(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func stopGatepostLogsProcessGroup(pid int) {
+	// gatepost-logs is started in a detached process group; kill the group so
+	// wrappers like `go run` do not leave the actual log server behind.
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil {
+		return
+	}
+	if p, err := os.FindProcess(pid); err == nil {
+		_ = p.Kill()
+	}
 }

--- a/target/gatepost_logs_unix.go
+++ b/target/gatepost_logs_unix.go
@@ -3,6 +3,8 @@
 package target
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -12,13 +14,19 @@ func detachGatepostLogsProcess(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-func stopGatepostLogsProcessGroup(pid int) {
+func stopGatepostLogsProcessGroup(pid int) error {
 	// gatepost-logs is started in a detached process group; kill the group so
 	// wrappers like `go run` do not leave the actual log server behind.
-	if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil {
-		return
+	groupErr := syscall.Kill(-pid, syscall.SIGKILL)
+	if groupErr == nil || errors.Is(groupErr, os.ErrProcessDone) || errors.Is(groupErr, syscall.ESRCH) {
+		return nil
 	}
-	if p, err := os.FindProcess(pid); err == nil {
-		_ = p.Kill()
+	p, findErr := os.FindProcess(pid)
+	if findErr != nil {
+		return fmt.Errorf("kill gatepost-logs process group %d: %w; find pid %d: %w", pid, groupErr, pid, findErr)
 	}
+	if killErr := p.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+		return fmt.Errorf("kill gatepost-logs process group %d: %w; fallback kill pid %d: %w", pid, groupErr, pid, killErr)
+	}
+	return nil
 }

--- a/target/gatepost_logs_windows.go
+++ b/target/gatepost_logs_windows.go
@@ -2,6 +2,15 @@
 
 package target
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+)
 
 func detachGatepostLogsProcess(_ *exec.Cmd) {}
+
+func stopGatepostLogsProcessGroup(pid int) {
+	if p, err := os.FindProcess(pid); err == nil {
+		_ = p.Kill()
+	}
+}

--- a/target/gatepost_logs_windows.go
+++ b/target/gatepost_logs_windows.go
@@ -3,14 +3,30 @@
 package target
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
+	"syscall"
 )
 
-func detachGatepostLogsProcess(_ *exec.Cmd) {}
+func detachGatepostLogsProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
 
-func stopGatepostLogsProcessGroup(pid int) {
-	if p, err := os.FindProcess(pid); err == nil {
-		_ = p.Kill()
+func stopGatepostLogsProcessGroup(pid int) error {
+	// taskkill /T terminates the wrapper plus child process tree, covering
+	// trusted-root launches that use `go run ./cmd/gatepost-logs`.
+	if err := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run(); err == nil {
+		return nil
 	}
+	p, findErr := os.FindProcess(pid)
+	if findErr != nil {
+		return fmt.Errorf("find gatepost-logs pid %d: %w", pid, findErr)
+	}
+	if killErr := p.Kill(); killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+		return fmt.Errorf("kill gatepost-logs pid %d: %w", pid, killErr)
+	}
+	return nil
 }

--- a/target/gatepost_pi.go
+++ b/target/gatepost_pi.go
@@ -59,8 +59,8 @@ func bootstrapGatepostProviderSecrets(cfg GatepostRuntimeConfig, gatepostRoot, c
 		result.Command = strings.Join(append([]string{cmdPath}, args...), " ")
 		cmd := exec.Command(cmdPath, args...)
 		cmd.Env = setEnv(os.Environ(), "GATEPOST_CONTROL_TOKEN", token)
-		if authHome := getenvDefault("DEVX_GATEPOST_AUTH_HOME", cfg.AuthHome); authHome != "" {
-			cmd.Env = setEnv(cmd.Env, "HOME", authHome)
+		if cfg.AuthHome != "" {
+			cmd.Env = setEnv(cmd.Env, "HOME", cfg.AuthHome)
 		}
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
@@ -97,10 +97,10 @@ func bootstrapGatepostProviderSecrets(cfg GatepostRuntimeConfig, gatepostRoot, c
 }
 
 func gatepostProviderBootstrapCommand(cfg GatepostRuntimeConfig, gatepostRoot, controlURL string) (string, []string, string, error) {
-	if raw := getenvDefault("DEVX_GATEPOST_PROVIDER_BOOTSTRAP_CMD", cfg.ProviderBootstrapCommand); raw != "" {
+	if raw := cfg.ProviderBootstrapCommand; raw != "" {
 		fields := strings.Fields(raw)
 		if len(fields) == 0 {
-			return "", nil, "", fmt.Errorf("DEVX_GATEPOST_PROVIDER_BOOTSTRAP_CMD is empty")
+			return "", nil, "", fmt.Errorf("gatepost.provider_bootstrap_command is empty")
 		}
 		return fields[0], append(fields[1:], controlURL), "command", nil
 	}

--- a/target/gatepost_pi_test.go
+++ b/target/gatepost_pi_test.go
@@ -26,3 +26,18 @@ func TestRequireGatepostProviders(t *testing.T) {
 		t.Fatal("expected missing provider error")
 	}
 }
+
+func TestGatepostProviderBootstrapCommandIgnoresEnvOverride(t *testing.T) {
+	t.Setenv("DEVX_GATEPOST_PROVIDER_BOOTSTRAP_CMD", "/tmp/untrusted-bootstrap")
+	cfg := GatepostRuntimeConfig{ProviderBootstrapCommand: "/trusted/bootstrap --flag"}
+	cmd, args, mode, err := gatepostProviderBootstrapCommand(cfg, "", "http://control")
+	if err != nil {
+		t.Fatalf("gatepostProviderBootstrapCommand: %v", err)
+	}
+	if cmd != "/trusted/bootstrap" || mode != "command" {
+		t.Fatalf("unexpected command/mode: %q %q", cmd, mode)
+	}
+	if len(args) != 2 || args[0] != "--flag" || args[1] != "http://control" {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}

--- a/target/gatepost_trust_unix.go
+++ b/target/gatepost_trust_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package target
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func validateTrustedGatepostOwner(path string, info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("could not inspect owner for trusted Gatepost path: %s", path)
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("trusted Gatepost path owner uid %d does not match current uid %d: %s", stat.Uid, os.Getuid(), path)
+	}
+	return nil
+}

--- a/target/gatepost_trust_windows.go
+++ b/target/gatepost_trust_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package target
+
+import "os"
+
+func validateTrustedGatepostOwner(_ string, _ os.FileInfo) error {
+	// Windows CI/builds do not expose syscall.Stat_t UIDs. Keep the mode and
+	// symlink/path-scope checks portable there.
+	return nil
+}

--- a/target/target.go
+++ b/target/target.go
@@ -33,8 +33,8 @@ type StartOpts struct {
 }
 
 // GatepostRuntimeConfig is the trusted host-side contract DevX passes to the
-// Gatepost target. Executable command paths should come from explicit env/CLI
-// or user-global config, never from project repo config.
+// Gatepost target. Executable command paths should come from trusted DevX
+// configuration, never from workspace-controlled project files or env.
 type GatepostRuntimeConfig struct {
 	Root                     string
 	LogsCommand              string


### PR DESCRIPTION
## Summary
- persist Gatepost sandbox agent home under `~/.local/share/devx/gatepost/<session>/agent-home`
- mount Pi, Codex, and Claude Code transcript/config dirs into Gatepost agent containers
- generate Claude/Codex Gatepost hook configs from trusted adapter roots
- harden trusted Gatepost helper/root handling and cleanup behavior
- remove Gatepost state on session removal and fail closed on cleanup errors

## Validation
- `go test ./...`
- `go vet ./...`
- live Gatepost sandbox smoke validated persisted `agent_home_dir`, mounts, hook config generation, synthetic Claude/Codex hook events, and proxied audit traffic
- final parallel subagent security/architecture/QA review round reported no medium+ blockers

## Notes
- Trusted executable/helper discovery now requires trusted DevX config (for example `gatepost.root` or explicit trusted helper commands), not workspace-influenced env overrides.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session removal reliability with stricter validation, cleanup procedures, and comprehensive error handling.
  * Enhanced Gatepost lifecycle operations with more robust cleanup on failures.
  * Better security protections against symlink-based path escape attempts.
  * Improved environment variable handling to prioritize trusted configuration.

* **Tests**
  * Expanded test coverage for session cleanup operations, path validation, adapter configuration, and trusted command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->